### PR TITLE
5.3.0 seller removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,13 @@ To configure these for your generated code, open the file "Configuration.go" and
 
 * [plans_pkg](#plans_pkg)
 * [subscriptions_pkg](#subscriptions_pkg)
-* [invoices_pkg](#invoices_pkg)
 * [orders_pkg](#orders_pkg)
+* [invoices_pkg](#invoices_pkg)
 * [customers_pkg](#customers_pkg)
-* [recipients_pkg](#recipients_pkg)
 * [charges_pkg](#charges_pkg)
 * [transfers_pkg](#transfers_pkg)
+* [recipients_pkg](#recipients_pkg)
 * [tokens_pkg](#tokens_pkg)
-* [sellers_pkg](#sellers_pkg)
 * [transactions_pkg](#transactions_pkg)
 
 ## <a name="plans_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".plans_pkg") plans_pkg
@@ -162,37 +161,6 @@ planId := "plan_id"
 
 var result *models_pkg.GetPlanResponse
 result,_ = plans.GetPlan(planId)
-
-```
-
-
-### <a name="delete_plan"></a>![Method: ](https://apidocs.io/img/method.png ".plans_pkg.DeletePlan") DeletePlan
-
-> Deletes a plan
-
-
-```go
-func (me *PLANS_IMPL) DeletePlan(
-            planId string,
-            idempotencyKey *string)(*models_pkg.GetPlanResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| planId |  ``` Required ```  | Plan id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-planId := "plan_id"
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetPlanResponse
-result,_ = plans.DeletePlan(planId, idempotencyKey)
 
 ```
 
@@ -430,8 +398,8 @@ func (me *PLANS_IMPL) GetPlans(
 #### Example Usage
 
 ```go
-page,_ := strconv.ParseInt("122", 10, 8)
-size,_ := strconv.ParseInt("122", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 name := "name"
 status := "status"
 billingType := "billing_type"
@@ -478,6 +446,37 @@ result,_ = plans.UpdatePlan(planId, request, idempotencyKey)
 ```
 
 
+### <a name="delete_plan"></a>![Method: ](https://apidocs.io/img/method.png ".plans_pkg.DeletePlan") DeletePlan
+
+> Deletes a plan
+
+
+```go
+func (me *PLANS_IMPL) DeletePlan(
+            planId string,
+            idempotencyKey *string)(*models_pkg.GetPlanResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| planId |  ``` Required ```  | Plan id |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+planId := "plan_id"
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetPlanResponse
+result,_ = plans.DeletePlan(planId, idempotencyKey)
+
+```
+
+
 [Back to List of Controllers](#list_of_controllers)
 
 ## <a name="subscriptions_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".subscriptions_pkg") subscriptions_pkg
@@ -489,37 +488,6 @@ Factory for the ``` SUBSCRIPTIONS ``` interface can be accessed from the package
 ```go
 subscriptions := subscriptions_pkg.NewSUBSCRIPTIONS()
 ```
-
-### <a name="renew_subscription"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.RenewSubscription") RenewSubscription
-
-> TODO: Add a method description
-
-
-```go
-func (me *SUBSCRIPTIONS_IMPL) RenewSubscription(
-            subscriptionId string,
-            idempotencyKey *string)(*models_pkg.GetPeriodResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | TODO: Add a parameter description |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-subscriptionId := "subscription_id"
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetPeriodResponse
-result,_ = subscriptions.RenewSubscription(subscriptionId, idempotencyKey)
-
-```
-
 
 ### <a name="update_subscription_card"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.UpdateSubscriptionCard") UpdateSubscriptionCard
 
@@ -694,6 +662,40 @@ result,_ = subscriptions.UpdateCurrentCycleStatus(subscriptionId, request, idemp
 ```
 
 
+### <a name="update_subscription_payment_method"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.UpdateSubscriptionPaymentMethod") UpdateSubscriptionPaymentMethod
+
+> Updates the payment method from a subscription
+
+
+```go
+func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionPaymentMethod(
+            subscriptionId string,
+            request *models_pkg.UpdateSubscriptionPaymentMethodRequest,
+            idempotencyKey *string)(*models_pkg.GetSubscriptionResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | Subscription id |
+| request |  ``` Required ```  | Request for updating the paymentmethod from a subscription |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+subscriptionId := "subscription_id"
+var request *models_pkg.UpdateSubscriptionPaymentMethodRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetSubscriptionResponse
+result,_ = subscriptions.UpdateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey)
+
+```
+
+
 ### <a name="delete_discount"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.DeleteDiscount") DeleteDiscount
 
 > Deletes a discount
@@ -765,8 +767,8 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionItems(
 
 ```go
 subscriptionId := "subscription_id"
-page,_ := strconv.ParseInt("122", 10, 8)
-size,_ := strconv.ParseInt("122", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 name := "name"
 code := "code"
 status := "status"
@@ -776,40 +778,6 @@ createdUntil := "created_until"
 
 var result *models_pkg.ListSubscriptionItemsResponse
 result,_ = subscriptions.GetSubscriptionItems(subscriptionId, page, size, name, code, status, description, createdSince, createdUntil)
-
-```
-
-
-### <a name="update_subscription_payment_method"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.UpdateSubscriptionPaymentMethod") UpdateSubscriptionPaymentMethod
-
-> Updates the payment method from a subscription
-
-
-```go
-func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionPaymentMethod(
-            subscriptionId string,
-            request *models_pkg.UpdateSubscriptionPaymentMethodRequest,
-            idempotencyKey *string)(*models_pkg.GetSubscriptionResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | Subscription id |
-| request |  ``` Required ```  | Request for updating the paymentmethod from a subscription |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-subscriptionId := "subscription_id"
-var request *models_pkg.UpdateSubscriptionPaymentMethodRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetSubscriptionResponse
-result,_ = subscriptions.UpdateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey)
 
 ```
 
@@ -887,8 +855,8 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptions(
 #### Example Usage
 
 ```go
-page,_ := strconv.ParseInt("122", 10, 8)
-size,_ := strconv.ParseInt("122", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 code := "code"
 billingType := "billing_type"
 customerId := "customer_id"
@@ -1011,37 +979,6 @@ result,_ = subscriptions.CreateUsage(subscriptionId, itemId, body, idempotencyKe
 ```
 
 
-### <a name="get_discount_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.GetDiscountById") GetDiscountById
-
-> TODO: Add a method description
-
-
-```go
-func (me *SUBSCRIPTIONS_IMPL) GetDiscountById(
-            subscriptionId string,
-            discountId string)(*models_pkg.GetDiscountResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | The subscription id |
-| discountId |  ``` Required ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-subscriptionId := "subscription_id"
-discountId := "discountId"
-
-var result *models_pkg.GetDiscountResponse
-result,_ = subscriptions.GetDiscountById(subscriptionId, discountId)
-
-```
-
-
 ### <a name="create_subscription"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.CreateSubscription") CreateSubscription
 
 > Creates a new subscription
@@ -1073,33 +1010,33 @@ result,_ = subscriptions.CreateSubscription(body, idempotencyKey)
 ```
 
 
-### <a name="get_increment_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.GetIncrementById") GetIncrementById
+### <a name="get_discount_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.GetDiscountById") GetDiscountById
 
 > TODO: Add a method description
 
 
 ```go
-func (me *SUBSCRIPTIONS_IMPL) GetIncrementById(
+func (me *SUBSCRIPTIONS_IMPL) GetDiscountById(
             subscriptionId string,
-            incrementId string)(*models_pkg.GetIncrementResponse,error)
+            discountId string)(*models_pkg.GetDiscountResponse,error)
 ```
 
 #### Parameters
 
 | Parameter | Tags | Description |
 |-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | The subscription Id |
-| incrementId |  ``` Required ```  | The increment Id |
+| subscriptionId |  ``` Required ```  | The subscription id |
+| discountId |  ``` Required ```  | TODO: Add a parameter description |
 
 
 #### Example Usage
 
 ```go
 subscriptionId := "subscription_id"
-incrementId := "increment_id"
+discountId := "discountId"
 
-var result *models_pkg.GetIncrementResponse
-result,_ = subscriptions.GetIncrementById(subscriptionId, incrementId)
+var result *models_pkg.GetDiscountResponse
+result,_ = subscriptions.GetDiscountById(subscriptionId, discountId)
 
 ```
 
@@ -1240,6 +1177,37 @@ result,_ = subscriptions.GetSubscriptionCycles(subscriptionId, page, size)
 ```
 
 
+### <a name="get_increment_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.GetIncrementById") GetIncrementById
+
+> TODO: Add a method description
+
+
+```go
+func (me *SUBSCRIPTIONS_IMPL) GetIncrementById(
+            subscriptionId string,
+            incrementId string)(*models_pkg.GetIncrementResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | The subscription Id |
+| incrementId |  ``` Required ```  | The increment Id |
+
+
+#### Example Usage
+
+```go
+subscriptionId := "subscription_id"
+incrementId := "increment_id"
+
+var result *models_pkg.GetIncrementResponse
+result,_ = subscriptions.GetIncrementById(subscriptionId, incrementId)
+
+```
+
+
 ### <a name="get_discounts"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.GetDiscounts") GetDiscounts
 
 > TODO: Add a method description
@@ -1265,8 +1233,8 @@ func (me *SUBSCRIPTIONS_IMPL) GetDiscounts(
 
 ```go
 subscriptionId := "subscription_id"
-page,_ := strconv.ParseInt("122", 10, 8)
-size,_ := strconv.ParseInt("122", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 
 var result *models_pkg.ListDiscountsResponse
 result,_ = subscriptions.GetDiscounts(subscriptionId, page, size)
@@ -1367,8 +1335,8 @@ func (me *SUBSCRIPTIONS_IMPL) GetIncrements(
 
 ```go
 subscriptionId := "subscription_id"
-page,_ := strconv.ParseInt("122", 10, 8)
-size,_ := strconv.ParseInt("122", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 
 var result *models_pkg.ListIncrementsResponse
 result,_ = subscriptions.GetIncrements(subscriptionId, page, size)
@@ -1578,8 +1546,8 @@ func (me *SUBSCRIPTIONS_IMPL) GetUsages(
 ```go
 subscriptionId := "subscription_id"
 itemId := "item_id"
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 code := "code"
 group := "group"
 usedSince := time.Now()
@@ -1690,6 +1658,37 @@ result,_ = subscriptions.GetSubscriptionCycleById(subscriptionId, cycleId)
 ```
 
 
+### <a name="renew_subscription"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.RenewSubscription") RenewSubscription
+
+> TODO: Add a method description
+
+
+```go
+func (me *SUBSCRIPTIONS_IMPL) RenewSubscription(
+            subscriptionId string,
+            idempotencyKey *string)(*models_pkg.GetPeriodResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | TODO: Add a parameter description |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+subscriptionId := "subscription_id"
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetPeriodResponse
+result,_ = subscriptions.RenewSubscription(subscriptionId, idempotencyKey)
+
+```
+
+
 ### <a name="get_usage_report"></a>![Method: ](https://apidocs.io/img/method.png ".subscriptions_pkg.GetUsageReport") GetUsageReport
 
 > TODO: Add a method description
@@ -1717,266 +1716,6 @@ periodId := "period_id"
 
 var result *models_pkg.GetUsageReportResponse
 result,_ = subscriptions.GetUsageReport(subscriptionId, periodId)
-
-```
-
-
-[Back to List of Controllers](#list_of_controllers)
-
-## <a name="invoices_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".invoices_pkg") invoices_pkg
-
-### Get instance
-
-Factory for the ``` INVOICES ``` interface can be accessed from the package invoices_pkg.
-
-```go
-invoices := invoices_pkg.NewINVOICES()
-```
-
-### <a name="update_invoice_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.UpdateInvoiceMetadata") UpdateInvoiceMetadata
-
-> Updates the metadata from an invoice
-
-
-```go
-func (me *INVOICES_IMPL) UpdateInvoiceMetadata(
-            invoiceId string,
-            request *models_pkg.UpdateMetadataRequest,
-            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | The invoice id |
-| request |  ``` Required ```  | Request for updating the invoice metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-invoiceId := "invoice_id"
-var request *models_pkg.UpdateMetadataRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetInvoiceResponse
-result,_ = invoices.UpdateInvoiceMetadata(invoiceId, request, idempotencyKey)
-
-```
-
-
-### <a name="get_partial_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.GetPartialInvoice") GetPartialInvoice
-
-> TODO: Add a method description
-
-
-```go
-func (me *INVOICES_IMPL) GetPartialInvoice(subscriptionId string)(*models_pkg.GetInvoiceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | Subscription Id |
-
-
-#### Example Usage
-
-```go
-subscriptionId := "subscription_id"
-
-var result *models_pkg.GetInvoiceResponse
-result,_ = invoices.GetPartialInvoice(subscriptionId)
-
-```
-
-
-### <a name="cancel_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.CancelInvoice") CancelInvoice
-
-> Cancels an invoice
-
-
-```go
-func (me *INVOICES_IMPL) CancelInvoice(
-            invoiceId string,
-            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | Invoice id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-invoiceId := "invoice_id"
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetInvoiceResponse
-result,_ = invoices.CancelInvoice(invoiceId, idempotencyKey)
-
-```
-
-
-### <a name="create_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.CreateInvoice") CreateInvoice
-
-> Create an Invoice
-
-
-```go
-func (me *INVOICES_IMPL) CreateInvoice(
-            subscriptionId string,
-            cycleId string,
-            request *models_pkg.CreateInvoiceRequest,
-            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | Subscription Id |
-| cycleId |  ``` Required ```  | Cycle Id |
-| request |  ``` Optional ```  | TODO: Add a parameter description |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-subscriptionId := "subscription_id"
-cycleId := "cycle_id"
-var request *models_pkg.CreateInvoiceRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetInvoiceResponse
-result,_ = invoices.CreateInvoice(subscriptionId, cycleId, request, idempotencyKey)
-
-```
-
-
-### <a name="get_invoices"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.GetInvoices") GetInvoices
-
-> Gets all invoices
-
-
-```go
-func (me *INVOICES_IMPL) GetInvoices(
-            page *int64,
-            size *int64,
-            code *string,
-            customerId *string,
-            subscriptionId *string,
-            createdSince *time.Time,
-            createdUntil *time.Time,
-            status *string,
-            dueSince *time.Time,
-            dueUntil *time.Time,
-            customerDocument *string)(*models_pkg.ListInvoicesResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| code |  ``` Optional ```  | Filter for Invoice's code |
-| customerId |  ``` Optional ```  | Filter for Invoice's customer id |
-| subscriptionId |  ``` Optional ```  | Filter for Invoice's subscription id |
-| createdSince |  ``` Optional ```  | Filter for Invoice's creation date start range |
-| createdUntil |  ``` Optional ```  | Filter for Invoices creation date end range |
-| status |  ``` Optional ```  | Filter for Invoice's status |
-| dueSince |  ``` Optional ```  | Filter for Invoice's due date start range |
-| dueUntil |  ``` Optional ```  | Filter for Invoice's due date end range |
-| customerDocument |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
-code := "code"
-customerId := "customer_id"
-subscriptionId := "subscription_id"
-createdSince := time.Now()
-createdUntil := time.Now()
-status := "status"
-dueSince := time.Now()
-dueUntil := time.Now()
-customerDocument := "customer_document"
-
-var result *models_pkg.ListInvoicesResponse
-result,_ = invoices.GetInvoices(page, size, code, customerId, subscriptionId, createdSince, createdUntil, status, dueSince, dueUntil, customerDocument)
-
-```
-
-
-### <a name="get_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.GetInvoice") GetInvoice
-
-> Gets an invoice
-
-
-```go
-func (me *INVOICES_IMPL) GetInvoice(invoiceId string)(*models_pkg.GetInvoiceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | Invoice Id |
-
-
-#### Example Usage
-
-```go
-invoiceId := "invoice_id"
-
-var result *models_pkg.GetInvoiceResponse
-result,_ = invoices.GetInvoice(invoiceId)
-
-```
-
-
-### <a name="update_invoice_status"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.UpdateInvoiceStatus") UpdateInvoiceStatus
-
-> Updates the status from an invoice
-
-
-```go
-func (me *INVOICES_IMPL) UpdateInvoiceStatus(
-            invoiceId string,
-            request *models_pkg.UpdateInvoiceStatusRequest,
-            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | Invoice Id |
-| request |  ``` Required ```  | Request for updating an invoice's status |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-invoiceId := "invoice_id"
-var request *models_pkg.UpdateInvoiceStatusRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetInvoiceResponse
-result,_ = invoices.UpdateInvoiceStatus(invoiceId, request, idempotencyKey)
 
 ```
 
@@ -2025,8 +1764,8 @@ func (me *ORDERS_IMPL) GetOrders(
 #### Example Usage
 
 ```go
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
+page,_ := strconv.ParseInt("245", 10, 8)
+size,_ := strconv.ParseInt("245", 10, 8)
 code := "code"
 status := "status"
 createdSince := time.Now()
@@ -2035,6 +1774,37 @@ customerId := "customer_id"
 
 var result *models_pkg.ListOrderResponse
 result,_ = orders.GetOrders(page, size, code, status, createdSince, createdUntil, customerId)
+
+```
+
+
+### <a name="delete_all_order_items"></a>![Method: ](https://apidocs.io/img/method.png ".orders_pkg.DeleteAllOrderItems") DeleteAllOrderItems
+
+> TODO: Add a method description
+
+
+```go
+func (me *ORDERS_IMPL) DeleteAllOrderItems(
+            orderId string,
+            idempotencyKey *string)(*models_pkg.GetOrderResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| orderId |  ``` Required ```  | Order Id |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+orderId := "orderId"
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetOrderResponse
+result,_ = orders.DeleteAllOrderItems(orderId, idempotencyKey)
 
 ```
 
@@ -2072,37 +1842,6 @@ idempotencyKey := "idempotency-key"
 
 var result *models_pkg.GetOrderItemResponse
 result,_ = orders.UpdateOrderItem(orderId, itemId, request, idempotencyKey)
-
-```
-
-
-### <a name="delete_all_order_items"></a>![Method: ](https://apidocs.io/img/method.png ".orders_pkg.DeleteAllOrderItems") DeleteAllOrderItems
-
-> TODO: Add a method description
-
-
-```go
-func (me *ORDERS_IMPL) DeleteAllOrderItems(
-            orderId string,
-            idempotencyKey *string)(*models_pkg.GetOrderResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| orderId |  ``` Required ```  | Order Id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-orderId := "orderId"
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetOrderResponse
-result,_ = orders.DeleteAllOrderItems(orderId, idempotencyKey)
 
 ```
 
@@ -2334,6 +2073,266 @@ result,_ = orders.GetOrder(orderId)
 
 [Back to List of Controllers](#list_of_controllers)
 
+## <a name="invoices_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".invoices_pkg") invoices_pkg
+
+### Get instance
+
+Factory for the ``` INVOICES ``` interface can be accessed from the package invoices_pkg.
+
+```go
+invoices := invoices_pkg.NewINVOICES()
+```
+
+### <a name="get_partial_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.GetPartialInvoice") GetPartialInvoice
+
+> TODO: Add a method description
+
+
+```go
+func (me *INVOICES_IMPL) GetPartialInvoice(subscriptionId string)(*models_pkg.GetInvoiceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | Subscription Id |
+
+
+#### Example Usage
+
+```go
+subscriptionId := "subscription_id"
+
+var result *models_pkg.GetInvoiceResponse
+result,_ = invoices.GetPartialInvoice(subscriptionId)
+
+```
+
+
+### <a name="cancel_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.CancelInvoice") CancelInvoice
+
+> Cancels an invoice
+
+
+```go
+func (me *INVOICES_IMPL) CancelInvoice(
+            invoiceId string,
+            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | Invoice id |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+invoiceId := "invoice_id"
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetInvoiceResponse
+result,_ = invoices.CancelInvoice(invoiceId, idempotencyKey)
+
+```
+
+
+### <a name="create_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.CreateInvoice") CreateInvoice
+
+> Create an Invoice
+
+
+```go
+func (me *INVOICES_IMPL) CreateInvoice(
+            subscriptionId string,
+            cycleId string,
+            request *models_pkg.CreateInvoiceRequest,
+            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | Subscription Id |
+| cycleId |  ``` Required ```  | Cycle Id |
+| request |  ``` Optional ```  | TODO: Add a parameter description |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+subscriptionId := "subscription_id"
+cycleId := "cycle_id"
+var request *models_pkg.CreateInvoiceRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetInvoiceResponse
+result,_ = invoices.CreateInvoice(subscriptionId, cycleId, request, idempotencyKey)
+
+```
+
+
+### <a name="update_invoice_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.UpdateInvoiceMetadata") UpdateInvoiceMetadata
+
+> Updates the metadata from an invoice
+
+
+```go
+func (me *INVOICES_IMPL) UpdateInvoiceMetadata(
+            invoiceId string,
+            request *models_pkg.UpdateMetadataRequest,
+            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | The invoice id |
+| request |  ``` Required ```  | Request for updating the invoice metadata |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+invoiceId := "invoice_id"
+var request *models_pkg.UpdateMetadataRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetInvoiceResponse
+result,_ = invoices.UpdateInvoiceMetadata(invoiceId, request, idempotencyKey)
+
+```
+
+
+### <a name="get_invoices"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.GetInvoices") GetInvoices
+
+> Gets all invoices
+
+
+```go
+func (me *INVOICES_IMPL) GetInvoices(
+            page *int64,
+            size *int64,
+            code *string,
+            customerId *string,
+            subscriptionId *string,
+            createdSince *time.Time,
+            createdUntil *time.Time,
+            status *string,
+            dueSince *time.Time,
+            dueUntil *time.Time,
+            customerDocument *string)(*models_pkg.ListInvoicesResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+| code |  ``` Optional ```  | Filter for Invoice's code |
+| customerId |  ``` Optional ```  | Filter for Invoice's customer id |
+| subscriptionId |  ``` Optional ```  | Filter for Invoice's subscription id |
+| createdSince |  ``` Optional ```  | Filter for Invoice's creation date start range |
+| createdUntil |  ``` Optional ```  | Filter for Invoices creation date end range |
+| status |  ``` Optional ```  | Filter for Invoice's status |
+| dueSince |  ``` Optional ```  | Filter for Invoice's due date start range |
+| dueUntil |  ``` Optional ```  | Filter for Invoice's due date end range |
+| customerDocument |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
+code := "code"
+customerId := "customer_id"
+subscriptionId := "subscription_id"
+createdSince := time.Now()
+createdUntil := time.Now()
+status := "status"
+dueSince := time.Now()
+dueUntil := time.Now()
+customerDocument := "customer_document"
+
+var result *models_pkg.ListInvoicesResponse
+result,_ = invoices.GetInvoices(page, size, code, customerId, subscriptionId, createdSince, createdUntil, status, dueSince, dueUntil, customerDocument)
+
+```
+
+
+### <a name="get_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.GetInvoice") GetInvoice
+
+> Gets an invoice
+
+
+```go
+func (me *INVOICES_IMPL) GetInvoice(invoiceId string)(*models_pkg.GetInvoiceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | Invoice Id |
+
+
+#### Example Usage
+
+```go
+invoiceId := "invoice_id"
+
+var result *models_pkg.GetInvoiceResponse
+result,_ = invoices.GetInvoice(invoiceId)
+
+```
+
+
+### <a name="update_invoice_status"></a>![Method: ](https://apidocs.io/img/method.png ".invoices_pkg.UpdateInvoiceStatus") UpdateInvoiceStatus
+
+> Updates the status from an invoice
+
+
+```go
+func (me *INVOICES_IMPL) UpdateInvoiceStatus(
+            invoiceId string,
+            request *models_pkg.UpdateInvoiceStatusRequest,
+            idempotencyKey *string)(*models_pkg.GetInvoiceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | Invoice Id |
+| request |  ``` Required ```  | Request for updating an invoice's status |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+invoiceId := "invoice_id"
+var request *models_pkg.UpdateInvoiceStatusRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetInvoiceResponse
+result,_ = invoices.UpdateInvoiceStatus(invoiceId, request, idempotencyKey)
+
+```
+
+
+[Back to List of Controllers](#list_of_controllers)
+
 ## <a name="customers_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".customers_pkg") customers_pkg
 
 ### Get instance
@@ -2452,33 +2451,36 @@ result,_ = customers.DeleteAccessToken(customerId, tokenId, idempotencyKey)
 ```
 
 
-### <a name="create_customer"></a>![Method: ](https://apidocs.io/img/method.png ".customers_pkg.CreateCustomer") CreateCustomer
+### <a name="create_access_token"></a>![Method: ](https://apidocs.io/img/method.png ".customers_pkg.CreateAccessToken") CreateAccessToken
 
-> Creates a new customer
+> Creates a access token for a customer
 
 
 ```go
-func (me *CUSTOMERS_IMPL) CreateCustomer(
-            request *models_pkg.CreateCustomerRequest,
-            idempotencyKey *string)(*models_pkg.GetCustomerResponse,error)
+func (me *CUSTOMERS_IMPL) CreateAccessToken(
+            customerId string,
+            request *models_pkg.CreateAccessTokenRequest,
+            idempotencyKey *string)(*models_pkg.GetAccessTokenResponse,error)
 ```
 
 #### Parameters
 
 | Parameter | Tags | Description |
 |-----------|------|-------------|
-| request |  ``` Required ```  | Request for creating a customer |
+| customerId |  ``` Required ```  | Customer Id |
+| request |  ``` Required ```  | Request for creating a access token |
 | idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
 
 
 #### Example Usage
 
 ```go
-var request *models_pkg.CreateCustomerRequest
+customerId := "customer_id"
+var request *models_pkg.CreateAccessTokenRequest
 idempotencyKey := "idempotency-key"
 
-var result *models_pkg.GetCustomerResponse
-result,_ = customers.CreateCustomer(request, idempotencyKey)
+var result *models_pkg.GetAccessTokenResponse
+result,_ = customers.CreateAccessToken(customerId, request, idempotencyKey)
 
 ```
 
@@ -2513,6 +2515,37 @@ idempotencyKey := "idempotency-key"
 
 var result *models_pkg.GetAddressResponse
 result,_ = customers.CreateAddress(customerId, request, idempotencyKey)
+
+```
+
+
+### <a name="create_customer"></a>![Method: ](https://apidocs.io/img/method.png ".customers_pkg.CreateCustomer") CreateCustomer
+
+> Creates a new customer
+
+
+```go
+func (me *CUSTOMERS_IMPL) CreateCustomer(
+            request *models_pkg.CreateCustomerRequest,
+            idempotencyKey *string)(*models_pkg.GetCustomerResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| request |  ``` Required ```  | Request for creating a customer |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+var request *models_pkg.CreateCustomerRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetCustomerResponse
+result,_ = customers.CreateCustomer(request, idempotencyKey)
 
 ```
 
@@ -2720,40 +2753,6 @@ result,_ = customers.UpdateCustomer(customerId, request, idempotencyKey)
 ```
 
 
-### <a name="create_access_token"></a>![Method: ](https://apidocs.io/img/method.png ".customers_pkg.CreateAccessToken") CreateAccessToken
-
-> Creates a access token for a customer
-
-
-```go
-func (me *CUSTOMERS_IMPL) CreateAccessToken(
-            customerId string,
-            request *models_pkg.CreateAccessTokenRequest,
-            idempotencyKey *string)(*models_pkg.GetAccessTokenResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| customerId |  ``` Required ```  | Customer Id |
-| request |  ``` Required ```  | Request for creating a access token |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-customerId := "customer_id"
-var request *models_pkg.CreateAccessTokenRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetAccessTokenResponse
-result,_ = customers.CreateAccessToken(customerId, request, idempotencyKey)
-
-```
-
-
 ### <a name="get_access_tokens"></a>![Method: ](https://apidocs.io/img/method.png ".customers_pkg.GetAccessTokens") GetAccessTokens
 
 > Get all access tokens from a customer
@@ -2779,8 +2778,8 @@ func (me *CUSTOMERS_IMPL) GetAccessTokens(
 
 ```go
 customerId := "customer_id"
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
 
 var result *models_pkg.ListAccessTokensResponse
 result,_ = customers.GetAccessTokens(customerId, page, size)
@@ -2813,8 +2812,8 @@ func (me *CUSTOMERS_IMPL) GetCards(
 
 ```go
 customerId := "customer_id"
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
 
 var result *models_pkg.ListCardsResponse
 result,_ = customers.GetCards(customerId, page, size)
@@ -2980,8 +2979,8 @@ func (me *CUSTOMERS_IMPL) GetAddresses(
 
 ```go
 customerId := "customer_id"
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
 
 var result *models_pkg.ListAddressesResponse
 result,_ = customers.GetAddresses(customerId, page, size)
@@ -3049,714 +3048,6 @@ result,_ = customers.GetCard(customerId, cardId)
 
 [Back to List of Controllers](#list_of_controllers)
 
-## <a name="recipients_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".recipients_pkg") recipients_pkg
-
-### Get instance
-
-Factory for the ``` RECIPIENTS ``` interface can be accessed from the package recipients_pkg.
-
-```go
-recipients := recipients_pkg.NewRECIPIENTS()
-```
-
-### <a name="update_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipient") UpdateRecipient
-
-> Updates a recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) UpdateRecipient(
-            recipientId string,
-            request *models_pkg.UpdateRecipientRequest,
-            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Recipient data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.UpdateRecipientRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.UpdateRecipient(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="create_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateAnticipation") CreateAnticipation
-
-> Creates an anticipation
-
-
-```go
-func (me *RECIPIENTS_IMPL) CreateAnticipation(
-            recipientId string,
-            request *models_pkg.CreateAnticipationRequest,
-            idempotencyKey *string)(*models_pkg.GetAnticipationResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Anticipation data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.CreateAnticipationRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetAnticipationResponse
-result,_ = recipients.CreateAnticipation(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="get_anticipation_limits"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetAnticipationLimits") GetAnticipationLimits
-
-> Gets the anticipation limits for a recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetAnticipationLimits(
-            recipientId string,
-            timeframe string,
-            paymentDate *time.Time)(*models_pkg.GetAnticipationLimitResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| timeframe |  ``` Required ```  | Timeframe |
-| paymentDate |  ``` Required ```  | Anticipation payment date |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-timeframe := "timeframe"
-paymentDate := time.Now()
-
-var result *models_pkg.GetAnticipationLimitResponse
-result,_ = recipients.GetAnticipationLimits(recipientId, timeframe, paymentDate)
-
-```
-
-
-### <a name="get_recipients"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetRecipients") GetRecipients
-
-> Retrieves paginated recipients information
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetRecipients(
-            page *int64,
-            size *int64)(*models_pkg.ListRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-
-
-#### Example Usage
-
-```go
-page,_ := strconv.ParseInt("80", 10, 8)
-size,_ := strconv.ParseInt("80", 10, 8)
-
-var result *models_pkg.ListRecipientResponse
-result,_ = recipients.GetRecipients(page, size)
-
-```
-
-
-### <a name="get_withdraw_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetWithdrawById") GetWithdrawById
-
-> TODO: Add a method description
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetWithdrawById(
-            recipientId string,
-            withdrawalId string)(*models_pkg.GetWithdrawResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | TODO: Add a parameter description |
-| withdrawalId |  ``` Required ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-withdrawalId := "withdrawal_id"
-
-var result *models_pkg.GetWithdrawResponse
-result,_ = recipients.GetWithdrawById(recipientId, withdrawalId)
-
-```
-
-
-### <a name="update_recipient_default_bank_account"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipientDefaultBankAccount") UpdateRecipientDefaultBankAccount
-
-> Updates the default bank account from a recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) UpdateRecipientDefaultBankAccount(
-            recipientId string,
-            request *models_pkg.UpdateRecipientBankAccountRequest,
-            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Bank account data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.UpdateRecipientBankAccountRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.UpdateRecipientDefaultBankAccount(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="update_recipient_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipientMetadata") UpdateRecipientMetadata
-
-> Updates recipient metadata
-
-
-```go
-func (me *RECIPIENTS_IMPL) UpdateRecipientMetadata(
-            recipientId string,
-            request *models_pkg.UpdateMetadataRequest,
-            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.UpdateMetadataRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.UpdateRecipientMetadata(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="get_transfers"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetTransfers") GetTransfers
-
-> Gets a paginated list of transfers for the recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetTransfers(
-            recipientId string,
-            page *int64,
-            size *int64,
-            status *string,
-            createdSince *time.Time,
-            createdUntil *time.Time)(*models_pkg.ListTransferResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| status |  ``` Optional ```  | Filter for transfer status |
-| createdSince |  ``` Optional ```  | Filter for start range of transfer creation date |
-| createdUntil |  ``` Optional ```  | Filter for end range of transfer creation date |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-page,_ := strconv.ParseInt("8", 10, 8)
-size,_ := strconv.ParseInt("8", 10, 8)
-status := "status"
-createdSince := time.Now()
-createdUntil := time.Now()
-
-var result *models_pkg.ListTransferResponse
-result,_ = recipients.GetTransfers(recipientId, page, size, status, createdSince, createdUntil)
-
-```
-
-
-### <a name="get_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetTransfer") GetTransfer
-
-> Gets a transfer
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetTransfer(
-            recipientId string,
-            transferId string)(*models_pkg.GetTransferResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| transferId |  ``` Required ```  | Transfer id |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-transferId := "transfer_id"
-
-var result *models_pkg.GetTransferResponse
-result,_ = recipients.GetTransfer(recipientId, transferId)
-
-```
-
-
-### <a name="create_withdraw"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateWithdraw") CreateWithdraw
-
-> TODO: Add a method description
-
-
-```go
-func (me *RECIPIENTS_IMPL) CreateWithdraw(
-            recipientId string,
-            request *models_pkg.CreateWithdrawRequest)(*models_pkg.GetWithdrawResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | TODO: Add a parameter description |
-| request |  ``` Required ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.CreateWithdrawRequest
-
-var result *models_pkg.GetWithdrawResponse
-result,_ = recipients.CreateWithdraw(recipientId, request)
-
-```
-
-
-### <a name="update_automatic_anticipation_settings"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateAutomaticAnticipationSettings") UpdateAutomaticAnticipationSettings
-
-> Updates recipient metadata
-
-
-```go
-func (me *RECIPIENTS_IMPL) UpdateAutomaticAnticipationSettings(
-            recipientId string,
-            request *models_pkg.UpdateAutomaticAnticipationSettingsRequest,
-            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.UpdateAutomaticAnticipationSettingsRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.UpdateAutomaticAnticipationSettings(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="get_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetAnticipation") GetAnticipation
-
-> Gets an anticipation
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetAnticipation(
-            recipientId string,
-            anticipationId string)(*models_pkg.GetAnticipationResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| anticipationId |  ``` Required ```  | Anticipation id |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-anticipationId := "anticipation_id"
-
-var result *models_pkg.GetAnticipationResponse
-result,_ = recipients.GetAnticipation(recipientId, anticipationId)
-
-```
-
-
-### <a name="update_recipient_transfer_settings"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipientTransferSettings") UpdateRecipientTransferSettings
-
-> TODO: Add a method description
-
-
-```go
-func (me *RECIPIENTS_IMPL) UpdateRecipientTransferSettings(
-            recipientId string,
-            request *models_pkg.UpdateTransferSettingsRequest,
-            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient Identificator |
-| request |  ``` Required ```  | TODO: Add a parameter description |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.UpdateTransferSettingsRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.UpdateRecipientTransferSettings(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="get_anticipations"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetAnticipations") GetAnticipations
-
-> Retrieves a paginated list of anticipations from a recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetAnticipations(
-            recipientId string,
-            page *int64,
-            size *int64,
-            status *string,
-            timeframe *string,
-            paymentDateSince *time.Time,
-            paymentDateUntil *time.Time,
-            createdSince *time.Time,
-            createdUntil *time.Time)(*models_pkg.ListAnticipationResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| status |  ``` Optional ```  | Filter for anticipation status |
-| timeframe |  ``` Optional ```  | Filter for anticipation timeframe |
-| paymentDateSince |  ``` Optional ```  | Filter for start range for anticipation payment date |
-| paymentDateUntil |  ``` Optional ```  | Filter for end range for anticipation payment date |
-| createdSince |  ``` Optional ```  | Filter for start range for anticipation creation date |
-| createdUntil |  ``` Optional ```  | Filter for end range for anticipation creation date |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-page,_ := strconv.ParseInt("8", 10, 8)
-size,_ := strconv.ParseInt("8", 10, 8)
-status := "status"
-timeframe := "timeframe"
-paymentDateSince := time.Now()
-paymentDateUntil := time.Now()
-createdSince := time.Now()
-createdUntil := time.Now()
-
-var result *models_pkg.ListAnticipationResponse
-result,_ = recipients.GetAnticipations(recipientId, page, size, status, timeframe, paymentDateSince, paymentDateUntil, createdSince, createdUntil)
-
-```
-
-
-### <a name="get_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetRecipient") GetRecipient
-
-> Retrieves recipient information
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetRecipient(recipientId string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipiend id |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.GetRecipient(recipientId)
-
-```
-
-
-### <a name="get_balance"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetBalance") GetBalance
-
-> Get balance information for a recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetBalance(recipientId string)(*models_pkg.GetBalanceResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-
-var result *models_pkg.GetBalanceResponse
-result,_ = recipients.GetBalance(recipientId)
-
-```
-
-
-### <a name="get_withdrawals"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetWithdrawals") GetWithdrawals
-
-> Gets a paginated list of transfers for the recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetWithdrawals(
-            recipientId string,
-            page *int64,
-            size *int64,
-            status *string,
-            createdSince *time.Time,
-            createdUntil *time.Time)(*models_pkg.ListWithdrawals,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | TODO: Add a parameter description |
-| page |  ``` Optional ```  | TODO: Add a parameter description |
-| size |  ``` Optional ```  | TODO: Add a parameter description |
-| status |  ``` Optional ```  | TODO: Add a parameter description |
-| createdSince |  ``` Optional ```  | TODO: Add a parameter description |
-| createdUntil |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-page,_ := strconv.ParseInt("8", 10, 8)
-size,_ := strconv.ParseInt("8", 10, 8)
-status := "status"
-createdSince := time.Now()
-createdUntil := time.Now()
-
-var result *models_pkg.ListWithdrawals
-result,_ = recipients.GetWithdrawals(recipientId, page, size, status, createdSince, createdUntil)
-
-```
-
-
-### <a name="create_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateTransfer") CreateTransfer
-
-> Creates a transfer for a recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) CreateTransfer(
-            recipientId string,
-            request *models_pkg.CreateTransferRequest,
-            idempotencyKey *string)(*models_pkg.GetTransferResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient Id |
-| request |  ``` Required ```  | Transfer data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-recipientId := "recipient_id"
-var request *models_pkg.CreateTransferRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetTransferResponse
-result,_ = recipients.CreateTransfer(recipientId, request, idempotencyKey)
-
-```
-
-
-### <a name="create_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateRecipient") CreateRecipient
-
-> Creates a new recipient
-
-
-```go
-func (me *RECIPIENTS_IMPL) CreateRecipient(
-            request *models_pkg.CreateRecipientRequest,
-            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| request |  ``` Required ```  | Recipient data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-var request *models_pkg.CreateRecipientRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.CreateRecipient(request, idempotencyKey)
-
-```
-
-
-### <a name="get_recipient_by_code"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetRecipientByCode") GetRecipientByCode
-
-> Retrieves recipient information
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetRecipientByCode(code string)(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| code |  ``` Required ```  | Recipient code |
-
-
-#### Example Usage
-
-```go
-code := "code"
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.GetRecipientByCode(code)
-
-```
-
-
-### <a name="get_default_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetDefaultRecipient") GetDefaultRecipient
-
-> TODO: Add a method description
-
-
-```go
-func (me *RECIPIENTS_IMPL) GetDefaultRecipient()(*models_pkg.GetRecipientResponse,error)
-```
-
-#### Example Usage
-
-```go
-
-var result *models_pkg.GetRecipientResponse
-result,_ = recipients.GetDefaultRecipient()
-
-```
-
-
-[Back to List of Controllers](#list_of_controllers)
-
 ## <a name="charges_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".charges_pkg") charges_pkg
 
 ### Get instance
@@ -3797,6 +3088,40 @@ idempotencyKey := "idempotency-key"
 
 var result *models_pkg.GetChargeResponse
 result,_ = charges.UpdateChargeMetadata(chargeId, request, idempotencyKey)
+
+```
+
+
+### <a name="capture_charge"></a>![Method: ](https://apidocs.io/img/method.png ".charges_pkg.CaptureCharge") CaptureCharge
+
+> Captures a charge
+
+
+```go
+func (me *CHARGES_IMPL) CaptureCharge(
+            chargeId string,
+            request *models_pkg.CreateCaptureChargeRequest,
+            idempotencyKey *string)(*models_pkg.GetChargeResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| chargeId |  ``` Required ```  | Charge id |
+| request |  ``` Optional ```  | Request for capturing a charge |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+chargeId := "charge_id"
+var request *models_pkg.CreateCaptureChargeRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetChargeResponse
+result,_ = charges.CaptureCharge(chargeId, request, idempotencyKey)
 
 ```
 
@@ -3860,8 +3185,8 @@ func (me *CHARGES_IMPL) GetChargeTransactions(
 
 ```go
 chargeId := "charge_id"
-page,_ := strconv.ParseInt("8", 10, 8)
-size,_ := strconv.ParseInt("8", 10, 8)
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
 
 var result *models_pkg.ListChargeTransactionsResponse
 result,_ = charges.GetChargeTransactions(chargeId, page, size)
@@ -3939,8 +3264,8 @@ func (me *CHARGES_IMPL) GetCharges(
 #### Example Usage
 
 ```go
-page,_ := strconv.ParseInt("8", 10, 8)
-size,_ := strconv.ParseInt("8", 10, 8)
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
 code := "code"
 status := "status"
 paymentMethod := "payment_method"
@@ -3951,40 +3276,6 @@ createdUntil := time.Now()
 
 var result *models_pkg.ListChargesResponse
 result,_ = charges.GetCharges(page, size, code, status, paymentMethod, customerId, orderId, createdSince, createdUntil)
-
-```
-
-
-### <a name="capture_charge"></a>![Method: ](https://apidocs.io/img/method.png ".charges_pkg.CaptureCharge") CaptureCharge
-
-> Captures a charge
-
-
-```go
-func (me *CHARGES_IMPL) CaptureCharge(
-            chargeId string,
-            request *models_pkg.CreateCaptureChargeRequest,
-            idempotencyKey *string)(*models_pkg.GetChargeResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| chargeId |  ``` Required ```  | Charge id |
-| request |  ``` Optional ```  | Request for capturing a charge |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-chargeId := "charge_id"
-var request *models_pkg.CreateCaptureChargeRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetChargeResponse
-result,_ = charges.CaptureCharge(chargeId, request, idempotencyKey)
 
 ```
 
@@ -4301,6 +3592,714 @@ result,_ = transfers.GetTransfers()
 
 [Back to List of Controllers](#list_of_controllers)
 
+## <a name="recipients_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".recipients_pkg") recipients_pkg
+
+### Get instance
+
+Factory for the ``` RECIPIENTS ``` interface can be accessed from the package recipients_pkg.
+
+```go
+recipients := recipients_pkg.NewRECIPIENTS()
+```
+
+### <a name="get_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetTransfer") GetTransfer
+
+> Gets a transfer
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetTransfer(
+            recipientId string,
+            transferId string)(*models_pkg.GetTransferResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| transferId |  ``` Required ```  | Transfer id |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+transferId := "transfer_id"
+
+var result *models_pkg.GetTransferResponse
+result,_ = recipients.GetTransfer(recipientId, transferId)
+
+```
+
+
+### <a name="update_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipient") UpdateRecipient
+
+> Updates a recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) UpdateRecipient(
+            recipientId string,
+            request *models_pkg.UpdateRecipientRequest,
+            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Recipient data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.UpdateRecipientRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.UpdateRecipient(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="create_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateAnticipation") CreateAnticipation
+
+> Creates an anticipation
+
+
+```go
+func (me *RECIPIENTS_IMPL) CreateAnticipation(
+            recipientId string,
+            request *models_pkg.CreateAnticipationRequest,
+            idempotencyKey *string)(*models_pkg.GetAnticipationResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Anticipation data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.CreateAnticipationRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetAnticipationResponse
+result,_ = recipients.CreateAnticipation(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="get_anticipation_limits"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetAnticipationLimits") GetAnticipationLimits
+
+> Gets the anticipation limits for a recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetAnticipationLimits(
+            recipientId string,
+            timeframe string,
+            paymentDate *time.Time)(*models_pkg.GetAnticipationLimitResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| timeframe |  ``` Required ```  | Timeframe |
+| paymentDate |  ``` Required ```  | Anticipation payment date |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+timeframe := "timeframe"
+paymentDate := time.Now()
+
+var result *models_pkg.GetAnticipationLimitResponse
+result,_ = recipients.GetAnticipationLimits(recipientId, timeframe, paymentDate)
+
+```
+
+
+### <a name="get_recipients"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetRecipients") GetRecipients
+
+> Retrieves paginated recipients information
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetRecipients(
+            page *int64,
+            size *int64)(*models_pkg.ListRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+
+
+#### Example Usage
+
+```go
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
+
+var result *models_pkg.ListRecipientResponse
+result,_ = recipients.GetRecipients(page, size)
+
+```
+
+
+### <a name="get_withdraw_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetWithdrawById") GetWithdrawById
+
+> TODO: Add a method description
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetWithdrawById(
+            recipientId string,
+            withdrawalId string)(*models_pkg.GetWithdrawResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | TODO: Add a parameter description |
+| withdrawalId |  ``` Required ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+withdrawalId := "withdrawal_id"
+
+var result *models_pkg.GetWithdrawResponse
+result,_ = recipients.GetWithdrawById(recipientId, withdrawalId)
+
+```
+
+
+### <a name="update_recipient_default_bank_account"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipientDefaultBankAccount") UpdateRecipientDefaultBankAccount
+
+> Updates the default bank account from a recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) UpdateRecipientDefaultBankAccount(
+            recipientId string,
+            request *models_pkg.UpdateRecipientBankAccountRequest,
+            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Bank account data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.UpdateRecipientBankAccountRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.UpdateRecipientDefaultBankAccount(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="update_recipient_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipientMetadata") UpdateRecipientMetadata
+
+> Updates recipient metadata
+
+
+```go
+func (me *RECIPIENTS_IMPL) UpdateRecipientMetadata(
+            recipientId string,
+            request *models_pkg.UpdateMetadataRequest,
+            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Metadata |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.UpdateMetadataRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.UpdateRecipientMetadata(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="get_transfers"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetTransfers") GetTransfers
+
+> Gets a paginated list of transfers for the recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetTransfers(
+            recipientId string,
+            page *int64,
+            size *int64,
+            status *string,
+            createdSince *time.Time,
+            createdUntil *time.Time)(*models_pkg.ListTransferResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+| status |  ``` Optional ```  | Filter for transfer status |
+| createdSince |  ``` Optional ```  | Filter for start range of transfer creation date |
+| createdUntil |  ``` Optional ```  | Filter for end range of transfer creation date |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
+status := "status"
+createdSince := time.Now()
+createdUntil := time.Now()
+
+var result *models_pkg.ListTransferResponse
+result,_ = recipients.GetTransfers(recipientId, page, size, status, createdSince, createdUntil)
+
+```
+
+
+### <a name="create_withdraw"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateWithdraw") CreateWithdraw
+
+> TODO: Add a method description
+
+
+```go
+func (me *RECIPIENTS_IMPL) CreateWithdraw(
+            recipientId string,
+            request *models_pkg.CreateWithdrawRequest)(*models_pkg.GetWithdrawResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | TODO: Add a parameter description |
+| request |  ``` Required ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.CreateWithdrawRequest
+
+var result *models_pkg.GetWithdrawResponse
+result,_ = recipients.CreateWithdraw(recipientId, request)
+
+```
+
+
+### <a name="update_automatic_anticipation_settings"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateAutomaticAnticipationSettings") UpdateAutomaticAnticipationSettings
+
+> Updates recipient metadata
+
+
+```go
+func (me *RECIPIENTS_IMPL) UpdateAutomaticAnticipationSettings(
+            recipientId string,
+            request *models_pkg.UpdateAutomaticAnticipationSettingsRequest,
+            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Metadata |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.UpdateAutomaticAnticipationSettingsRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.UpdateAutomaticAnticipationSettings(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="get_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetAnticipation") GetAnticipation
+
+> Gets an anticipation
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetAnticipation(
+            recipientId string,
+            anticipationId string)(*models_pkg.GetAnticipationResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| anticipationId |  ``` Required ```  | Anticipation id |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+anticipationId := "anticipation_id"
+
+var result *models_pkg.GetAnticipationResponse
+result,_ = recipients.GetAnticipation(recipientId, anticipationId)
+
+```
+
+
+### <a name="update_recipient_transfer_settings"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.UpdateRecipientTransferSettings") UpdateRecipientTransferSettings
+
+> TODO: Add a method description
+
+
+```go
+func (me *RECIPIENTS_IMPL) UpdateRecipientTransferSettings(
+            recipientId string,
+            request *models_pkg.UpdateTransferSettingsRequest,
+            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient Identificator |
+| request |  ``` Required ```  | TODO: Add a parameter description |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.UpdateTransferSettingsRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.UpdateRecipientTransferSettings(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="get_anticipations"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetAnticipations") GetAnticipations
+
+> Retrieves a paginated list of anticipations from a recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetAnticipations(
+            recipientId string,
+            page *int64,
+            size *int64,
+            status *string,
+            timeframe *string,
+            paymentDateSince *time.Time,
+            paymentDateUntil *time.Time,
+            createdSince *time.Time,
+            createdUntil *time.Time)(*models_pkg.ListAnticipationResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+| status |  ``` Optional ```  | Filter for anticipation status |
+| timeframe |  ``` Optional ```  | Filter for anticipation timeframe |
+| paymentDateSince |  ``` Optional ```  | Filter for start range for anticipation payment date |
+| paymentDateUntil |  ``` Optional ```  | Filter for end range for anticipation payment date |
+| createdSince |  ``` Optional ```  | Filter for start range for anticipation creation date |
+| createdUntil |  ``` Optional ```  | Filter for end range for anticipation creation date |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
+status := "status"
+timeframe := "timeframe"
+paymentDateSince := time.Now()
+paymentDateUntil := time.Now()
+createdSince := time.Now()
+createdUntil := time.Now()
+
+var result *models_pkg.ListAnticipationResponse
+result,_ = recipients.GetAnticipations(recipientId, page, size, status, timeframe, paymentDateSince, paymentDateUntil, createdSince, createdUntil)
+
+```
+
+
+### <a name="get_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetRecipient") GetRecipient
+
+> Retrieves recipient information
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetRecipient(recipientId string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipiend id |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.GetRecipient(recipientId)
+
+```
+
+
+### <a name="get_withdrawals"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetWithdrawals") GetWithdrawals
+
+> Gets a paginated list of transfers for the recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetWithdrawals(
+            recipientId string,
+            page *int64,
+            size *int64,
+            status *string,
+            createdSince *time.Time,
+            createdUntil *time.Time)(*models_pkg.ListWithdrawals,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | TODO: Add a parameter description |
+| page |  ``` Optional ```  | TODO: Add a parameter description |
+| size |  ``` Optional ```  | TODO: Add a parameter description |
+| status |  ``` Optional ```  | TODO: Add a parameter description |
+| createdSince |  ``` Optional ```  | TODO: Add a parameter description |
+| createdUntil |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+page,_ := strconv.ParseInt("82", 10, 8)
+size,_ := strconv.ParseInt("82", 10, 8)
+status := "status"
+createdSince := time.Now()
+createdUntil := time.Now()
+
+var result *models_pkg.ListWithdrawals
+result,_ = recipients.GetWithdrawals(recipientId, page, size, status, createdSince, createdUntil)
+
+```
+
+
+### <a name="get_balance"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetBalance") GetBalance
+
+> Get balance information for a recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetBalance(recipientId string)(*models_pkg.GetBalanceResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+
+var result *models_pkg.GetBalanceResponse
+result,_ = recipients.GetBalance(recipientId)
+
+```
+
+
+### <a name="create_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateTransfer") CreateTransfer
+
+> Creates a transfer for a recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) CreateTransfer(
+            recipientId string,
+            request *models_pkg.CreateTransferRequest,
+            idempotencyKey *string)(*models_pkg.GetTransferResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient Id |
+| request |  ``` Required ```  | Transfer data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+recipientId := "recipient_id"
+var request *models_pkg.CreateTransferRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetTransferResponse
+result,_ = recipients.CreateTransfer(recipientId, request, idempotencyKey)
+
+```
+
+
+### <a name="create_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.CreateRecipient") CreateRecipient
+
+> Creates a new recipient
+
+
+```go
+func (me *RECIPIENTS_IMPL) CreateRecipient(
+            request *models_pkg.CreateRecipientRequest,
+            idempotencyKey *string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| request |  ``` Required ```  | Recipient data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+#### Example Usage
+
+```go
+var request *models_pkg.CreateRecipientRequest
+idempotencyKey := "idempotency-key"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.CreateRecipient(request, idempotencyKey)
+
+```
+
+
+### <a name="get_recipient_by_code"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetRecipientByCode") GetRecipientByCode
+
+> Retrieves recipient information
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetRecipientByCode(code string)(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| code |  ``` Required ```  | Recipient code |
+
+
+#### Example Usage
+
+```go
+code := "code"
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.GetRecipientByCode(code)
+
+```
+
+
+### <a name="get_default_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".recipients_pkg.GetDefaultRecipient") GetDefaultRecipient
+
+> TODO: Add a method description
+
+
+```go
+func (me *RECIPIENTS_IMPL) GetDefaultRecipient()(*models_pkg.GetRecipientResponse,error)
+```
+
+#### Example Usage
+
+```go
+
+var result *models_pkg.GetRecipientResponse
+result,_ = recipients.GetDefaultRecipient()
+
+```
+
+
+[Back to List of Controllers](#list_of_controllers)
+
 ## <a name="tokens_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".tokens_pkg") tokens_pkg
 
 ### Get instance
@@ -4376,227 +4375,6 @@ publicKey := "public_key"
 
 var result *models_pkg.GetTokenResponse
 result,_ = tokens.GetToken(id, publicKey)
-
-```
-
-
-[Back to List of Controllers](#list_of_controllers)
-
-## <a name="sellers_pkg"></a>![Class: ](https://apidocs.io/img/class.png ".sellers_pkg") sellers_pkg
-
-### Get instance
-
-Factory for the ``` SELLERS ``` interface can be accessed from the package sellers_pkg.
-
-```go
-sellers := sellers_pkg.NewSELLERS()
-```
-
-### <a name="create_seller"></a>![Method: ](https://apidocs.io/img/method.png ".sellers_pkg.CreateSeller") CreateSeller
-
-> TODO: Add a method description
-
-
-```go
-func (me *SELLERS_IMPL) CreateSeller(
-            request *models_pkg.CreateSellerRequest,
-            idempotencyKey *string)(*models_pkg.GetSellerResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| request |  ``` Required ```  | Seller Model |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-var request *models_pkg.CreateSellerRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetSellerResponse
-result,_ = sellers.CreateSeller(request, idempotencyKey)
-
-```
-
-
-### <a name="update_seller_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".sellers_pkg.UpdateSellerMetadata") UpdateSellerMetadata
-
-> TODO: Add a method description
-
-
-```go
-func (me *SELLERS_IMPL) UpdateSellerMetadata(
-            sellerId string,
-            request *models_pkg.UpdateMetadataRequest,
-            idempotencyKey *string)(*models_pkg.GetSellerResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| sellerId |  ``` Required ```  | Seller Id |
-| request |  ``` Required ```  | Request for updating the charge metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-sellerId := "seller_id"
-var request *models_pkg.UpdateMetadataRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetSellerResponse
-result,_ = sellers.UpdateSellerMetadata(sellerId, request, idempotencyKey)
-
-```
-
-
-### <a name="update_seller"></a>![Method: ](https://apidocs.io/img/method.png ".sellers_pkg.UpdateSeller") UpdateSeller
-
-> TODO: Add a method description
-
-
-```go
-func (me *SELLERS_IMPL) UpdateSeller(
-            id string,
-            request *models_pkg.UpdateSellerRequest,
-            idempotencyKey *string)(*models_pkg.GetSellerResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| id |  ``` Required ```  | TODO: Add a parameter description |
-| request |  ``` Required ```  | Update Seller model |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-id := "id"
-var request *models_pkg.UpdateSellerRequest
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetSellerResponse
-result,_ = sellers.UpdateSeller(id, request, idempotencyKey)
-
-```
-
-
-### <a name="delete_seller"></a>![Method: ](https://apidocs.io/img/method.png ".sellers_pkg.DeleteSeller") DeleteSeller
-
-> TODO: Add a method description
-
-
-```go
-func (me *SELLERS_IMPL) DeleteSeller(
-            sellerId string,
-            idempotencyKey *string)(*models_pkg.GetSellerResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| sellerId |  ``` Required ```  | Seller Id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-sellerId := "sellerId"
-idempotencyKey := "idempotency-key"
-
-var result *models_pkg.GetSellerResponse
-result,_ = sellers.DeleteSeller(sellerId, idempotencyKey)
-
-```
-
-
-### <a name="get_seller_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".sellers_pkg.GetSellerById") GetSellerById
-
-> TODO: Add a method description
-
-
-```go
-func (me *SELLERS_IMPL) GetSellerById(id string)(*models_pkg.GetSellerResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| id |  ``` Required ```  | Seller Id |
-
-
-#### Example Usage
-
-```go
-id := "id"
-
-var result *models_pkg.GetSellerResponse
-result,_ = sellers.GetSellerById(id)
-
-```
-
-
-### <a name="get_sellers"></a>![Method: ](https://apidocs.io/img/method.png ".sellers_pkg.GetSellers") GetSellers
-
-> TODO: Add a method description
-
-
-```go
-func (me *SELLERS_IMPL) GetSellers(
-            page *int64,
-            size *int64,
-            name *string,
-            document *string,
-            code *string,
-            status *string,
-            mtype *string,
-            createdSince *time.Time,
-            createdUntil *time.Time)(*models_pkg.ListSellerResponse,error)
-```
-
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| name |  ``` Optional ```  | TODO: Add a parameter description |
-| document |  ``` Optional ```  | TODO: Add a parameter description |
-| code |  ``` Optional ```  | TODO: Add a parameter description |
-| status |  ``` Optional ```  | TODO: Add a parameter description |
-| mtype |  ``` Optional ```  | TODO: Add a parameter description |
-| createdSince |  ``` Optional ```  | TODO: Add a parameter description |
-| createdUntil |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-#### Example Usage
-
-```go
-page,_ := strconv.ParseInt("8", 10, 8)
-size,_ := strconv.ParseInt("8", 10, 8)
-name := "name"
-document := "document"
-code := "code"
-status := "status"
-mtype := "type"
-createdSince := time.Now()
-createdUntil := time.Now()
-
-var result *models_pkg.ListSellerResponse
-result,_ = sellers.GetSellers(page, size, name, document, code, status, mtype, createdSince, createdUntil)
 
 ```
 

--- a/src/pagarmecoreapi_lib/charges_pkg/Charges.go
+++ b/src/pagarmecoreapi_lib/charges_pkg/Charges.go
@@ -16,6 +16,8 @@ import "pagarmecoreapi_lib/models_pkg"
 type CHARGES interface {
     UpdateChargeMetadata (string, *models_pkg.UpdateMetadataRequest, *string) (*models_pkg.GetChargeResponse, error)
 
+    CaptureCharge (string, *models_pkg.CreateCaptureChargeRequest, *string) (*models_pkg.GetChargeResponse, error)
+
     UpdateChargePaymentMethod (string, *models_pkg.UpdateChargePaymentMethodRequest, *string) (*models_pkg.GetChargeResponse, error)
 
     GetChargeTransactions (string, *int64, *int64) (*models_pkg.ListChargeTransactionsResponse, error)
@@ -23,8 +25,6 @@ type CHARGES interface {
     UpdateChargeDueDate (string, *models_pkg.UpdateChargeDueDateRequest, *string) (*models_pkg.GetChargeResponse, error)
 
     GetCharges (*int64, *int64, *string, *string, *string, *string, *string, *time.Time, *time.Time) (*models_pkg.ListChargesResponse, error)
-
-    CaptureCharge (string, *models_pkg.CreateCaptureChargeRequest, *string) (*models_pkg.GetChargeResponse, error)
 
     UpdateChargeCard (string, *models_pkg.UpdateChargeCardRequest, *string) (*models_pkg.GetChargeResponse, error)
 

--- a/src/pagarmecoreapi_lib/charges_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/charges_pkg/Client.go
@@ -61,7 +61,7 @@ func (me *CHARGES_IMPL) UpdateChargeMetadata (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -69,6 +69,93 @@ func (me *CHARGES_IMPL) UpdateChargeMetadata (
 
     //prepare API request
     _request := unirest.PatchWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetChargeResponse = &models_pkg.GetChargeResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * Captures a charge
+ * @param    string                                        chargeId            parameter: Required
+ * @param    *models_pkg.CreateCaptureChargeRequest        request             parameter: Optional
+ * @param    *string                                       idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetChargeResponse response from the API call
+ */
+func (me *CHARGES_IMPL) CaptureCharge (
+            chargeId string,
+            request *models_pkg.CreateCaptureChargeRequest,
+            idempotencyKey *string) (*models_pkg.GetChargeResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/charges/{charge_id}/capture"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "charge_id" : chargeId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "content-type" : "application/json; charset=utf-8",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.PostWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
     //and invoke the API call request to fetch the response
     _response, err := unirest.AsString(_request,false);
     if err != nil {
@@ -148,7 +235,7 @@ func (me *CHARGES_IMPL) UpdateChargePaymentMethod (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -245,7 +332,7 @@ func (me *CHARGES_IMPL) GetChargeTransactions (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -330,7 +417,7 @@ func (me *CHARGES_IMPL) UpdateChargeDueDate (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -437,7 +524,7 @@ func (me *CHARGES_IMPL) GetCharges (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -473,93 +560,6 @@ func (me *CHARGES_IMPL) GetCharges (
 
     //returning the response
     var retVal *models_pkg.ListChargesResponse = &models_pkg.ListChargesResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * Captures a charge
- * @param    string                                        chargeId            parameter: Required
- * @param    *models_pkg.CreateCaptureChargeRequest        request             parameter: Optional
- * @param    *string                                       idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetChargeResponse response from the API call
- */
-func (me *CHARGES_IMPL) CaptureCharge (
-            chargeId string,
-            request *models_pkg.CreateCaptureChargeRequest,
-            idempotencyKey *string) (*models_pkg.GetChargeResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/charges/{charge_id}/capture"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "charge_id" : chargeId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "content-type" : "application/json; charset=utf-8",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.PostWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetChargeResponse = &models_pkg.GetChargeResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -609,7 +609,7 @@ func (me *CHARGES_IMPL) UpdateChargeCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -692,7 +692,7 @@ func (me *CHARGES_IMPL) GetCharge (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -779,7 +779,7 @@ func (me *CHARGES_IMPL) GetChargesSummary (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -862,7 +862,7 @@ func (me *CHARGES_IMPL) RetryCharge (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -948,7 +948,7 @@ func (me *CHARGES_IMPL) CancelCharge (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1024,7 +1024,7 @@ func (me *CHARGES_IMPL) CreateCharge (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1111,7 +1111,7 @@ func (me *CHARGES_IMPL) ConfirmPayment (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),

--- a/src/pagarmecoreapi_lib/customers_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/customers_pkg/Client.go
@@ -63,7 +63,7 @@ func (me *CUSTOMERS_IMPL) UpdateCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -153,7 +153,7 @@ func (me *CUSTOMERS_IMPL) UpdateAddress (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -241,7 +241,7 @@ func (me *CUSTOMERS_IMPL) DeleteAccessToken (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -289,19 +289,30 @@ func (me *CUSTOMERS_IMPL) DeleteAccessToken (
 }
 
 /**
- * Creates a new customer
- * @param    *models_pkg.CreateCustomerRequest        request             parameter: Required
- * @param    *string                                  idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetCustomerResponse response from the API call
+ * Creates a access token for a customer
+ * @param    string                                      customerId          parameter: Required
+ * @param    *models_pkg.CreateAccessTokenRequest        request             parameter: Required
+ * @param    *string                                     idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetAccessTokenResponse response from the API call
  */
-func (me *CUSTOMERS_IMPL) CreateCustomer (
-            request *models_pkg.CreateCustomerRequest,
-            idempotencyKey *string) (*models_pkg.GetCustomerResponse, error) {
+func (me *CUSTOMERS_IMPL) CreateAccessToken (
+            customerId string,
+            request *models_pkg.CreateAccessTokenRequest,
+            idempotencyKey *string) (*models_pkg.GetAccessTokenResponse, error) {
     //the endpoint path uri
-    _pathUrl := "/customers"
+    _pathUrl := "/customers/{customer_id}/access-tokens"
 
     //variable to hold errors
     var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "customer_id" : customerId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
     //the base uri for api requests
     _queryBuilder := configuration_pkg.BASEURI;
 
@@ -316,7 +327,7 @@ func (me *CUSTOMERS_IMPL) CreateCustomer (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -353,7 +364,7 @@ func (me *CUSTOMERS_IMPL) CreateCustomer (
     }
 
     //returning the response
-    var retVal *models_pkg.GetCustomerResponse = &models_pkg.GetCustomerResponse{}
+    var retVal *models_pkg.GetAccessTokenResponse = &models_pkg.GetAccessTokenResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -403,7 +414,7 @@ func (me *CUSTOMERS_IMPL) CreateAddress (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -452,6 +463,82 @@ func (me *CUSTOMERS_IMPL) CreateAddress (
 }
 
 /**
+ * Creates a new customer
+ * @param    *models_pkg.CreateCustomerRequest        request             parameter: Required
+ * @param    *string                                  idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetCustomerResponse response from the API call
+ */
+func (me *CUSTOMERS_IMPL) CreateCustomer (
+            request *models_pkg.CreateCustomerRequest,
+            idempotencyKey *string) (*models_pkg.GetCustomerResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/customers"
+
+    //variable to hold errors
+    var err error = nil
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "content-type" : "application/json; charset=utf-8",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.PostWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetCustomerResponse = &models_pkg.GetCustomerResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
  * Delete a Customer's access tokens
  * @param    string        customerId      parameter: Required
  * @return	Returns the *models_pkg.ListAccessTokensResponse response from the API call
@@ -486,7 +573,7 @@ func (me *CUSTOMERS_IMPL) DeleteAccessTokens (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -570,7 +657,7 @@ func (me *CUSTOMERS_IMPL) GetAddress (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -656,7 +743,7 @@ func (me *CUSTOMERS_IMPL) DeleteAddress (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -742,7 +829,7 @@ func (me *CUSTOMERS_IMPL) CreateCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -840,7 +927,7 @@ func (me *CUSTOMERS_IMPL) GetCustomers (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -925,7 +1012,7 @@ func (me *CUSTOMERS_IMPL) UpdateCustomer (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -963,93 +1050,6 @@ func (me *CUSTOMERS_IMPL) UpdateCustomer (
 
     //returning the response
     var retVal *models_pkg.GetCustomerResponse = &models_pkg.GetCustomerResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * Creates a access token for a customer
- * @param    string                                      customerId          parameter: Required
- * @param    *models_pkg.CreateAccessTokenRequest        request             parameter: Required
- * @param    *string                                     idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetAccessTokenResponse response from the API call
- */
-func (me *CUSTOMERS_IMPL) CreateAccessToken (
-            customerId string,
-            request *models_pkg.CreateAccessTokenRequest,
-            idempotencyKey *string) (*models_pkg.GetAccessTokenResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/customers/{customer_id}/access-tokens"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "customer_id" : customerId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "content-type" : "application/json; charset=utf-8",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.PostWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetAccessTokenResponse = &models_pkg.GetAccessTokenResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -1109,7 +1109,7 @@ func (me *CUSTOMERS_IMPL) GetAccessTokens (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1204,7 +1204,7 @@ func (me *CUSTOMERS_IMPL) GetCards (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1290,7 +1290,7 @@ func (me *CUSTOMERS_IMPL) RenewCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -1375,7 +1375,7 @@ func (me *CUSTOMERS_IMPL) GetAccessToken (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1460,7 +1460,7 @@ func (me *CUSTOMERS_IMPL) UpdateCustomerMetadata (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1548,7 +1548,7 @@ func (me *CUSTOMERS_IMPL) DeleteCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -1644,7 +1644,7 @@ func (me *CUSTOMERS_IMPL) GetAddresses (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1725,7 +1725,7 @@ func (me *CUSTOMERS_IMPL) GetCustomer (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1809,7 +1809,7 @@ func (me *CUSTOMERS_IMPL) GetCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 

--- a/src/pagarmecoreapi_lib/customers_pkg/Customers.go
+++ b/src/pagarmecoreapi_lib/customers_pkg/Customers.go
@@ -19,9 +19,11 @@ type CUSTOMERS interface {
 
     DeleteAccessToken (string, string, *string) (*models_pkg.GetAccessTokenResponse, error)
 
-    CreateCustomer (*models_pkg.CreateCustomerRequest, *string) (*models_pkg.GetCustomerResponse, error)
+    CreateAccessToken (string, *models_pkg.CreateAccessTokenRequest, *string) (*models_pkg.GetAccessTokenResponse, error)
 
     CreateAddress (string, *models_pkg.CreateAddressRequest, *string) (*models_pkg.GetAddressResponse, error)
+
+    CreateCustomer (*models_pkg.CreateCustomerRequest, *string) (*models_pkg.GetCustomerResponse, error)
 
     DeleteAccessTokens (string) (*models_pkg.ListAccessTokensResponse, error)
 
@@ -34,8 +36,6 @@ type CUSTOMERS interface {
     GetCustomers (*string, *string, *int64, *int64, *string, *string) (*models_pkg.ListCustomersResponse, error)
 
     UpdateCustomer (string, *models_pkg.UpdateCustomerRequest, *string) (*models_pkg.GetCustomerResponse, error)
-
-    CreateAccessToken (string, *models_pkg.CreateAccessTokenRequest, *string) (*models_pkg.GetAccessTokenResponse, error)
 
     GetAccessTokens (string, *int64, *int64) (*models_pkg.ListAccessTokensResponse, error)
 

--- a/src/pagarmecoreapi_lib/invoices_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/invoices_pkg/Client.go
@@ -23,93 +23,6 @@ type INVOICES_IMPL struct {
 }
 
 /**
- * Updates the metadata from an invoice
- * @param    string                                   invoiceId           parameter: Required
- * @param    *models_pkg.UpdateMetadataRequest        request             parameter: Required
- * @param    *string                                  idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetInvoiceResponse response from the API call
- */
-func (me *INVOICES_IMPL) UpdateInvoiceMetadata (
-            invoiceId string,
-            request *models_pkg.UpdateMetadataRequest,
-            idempotencyKey *string) (*models_pkg.GetInvoiceResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/invoices/{invoice_id}/metadata"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "invoice_id" : invoiceId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "content-type" : "application/json; charset=utf-8",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.PatchWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetInvoiceResponse = &models_pkg.GetInvoiceResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
  * TODO: type endpoint description here
  * @param    string        subscriptionId      parameter: Required
  * @return	Returns the *models_pkg.GetInvoiceResponse response from the API call
@@ -144,7 +57,7 @@ func (me *INVOICES_IMPL) GetPartialInvoice (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -227,7 +140,7 @@ func (me *INVOICES_IMPL) CancelInvoice (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -316,7 +229,7 @@ func (me *INVOICES_IMPL) CreateInvoice (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -324,6 +237,93 @@ func (me *INVOICES_IMPL) CreateInvoice (
 
     //prepare API request
     _request := unirest.PostWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetInvoiceResponse = &models_pkg.GetInvoiceResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * Updates the metadata from an invoice
+ * @param    string                                   invoiceId           parameter: Required
+ * @param    *models_pkg.UpdateMetadataRequest        request             parameter: Required
+ * @param    *string                                  idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetInvoiceResponse response from the API call
+ */
+func (me *INVOICES_IMPL) UpdateInvoiceMetadata (
+            invoiceId string,
+            request *models_pkg.UpdateMetadataRequest,
+            idempotencyKey *string) (*models_pkg.GetInvoiceResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/invoices/{invoice_id}/metadata"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "invoice_id" : invoiceId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "content-type" : "application/json; charset=utf-8",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.PatchWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
     //and invoke the API call request to fetch the response
     _response, err := unirest.AsString(_request,false);
     if err != nil {
@@ -429,7 +429,7 @@ func (me *INVOICES_IMPL) GetInvoices (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -510,7 +510,7 @@ func (me *INVOICES_IMPL) GetInvoice (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -595,7 +595,7 @@ func (me *INVOICES_IMPL) UpdateInvoiceStatus (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),

--- a/src/pagarmecoreapi_lib/invoices_pkg/Invoices.go
+++ b/src/pagarmecoreapi_lib/invoices_pkg/Invoices.go
@@ -14,13 +14,13 @@ import "pagarmecoreapi_lib/models_pkg"
  * Interface for the INVOICES_IMPL
  */
 type INVOICES interface {
-    UpdateInvoiceMetadata (string, *models_pkg.UpdateMetadataRequest, *string) (*models_pkg.GetInvoiceResponse, error)
-
     GetPartialInvoice (string) (*models_pkg.GetInvoiceResponse, error)
 
     CancelInvoice (string, *string) (*models_pkg.GetInvoiceResponse, error)
 
     CreateInvoice (string, string, *models_pkg.CreateInvoiceRequest, *string) (*models_pkg.GetInvoiceResponse, error)
+
+    UpdateInvoiceMetadata (string, *models_pkg.UpdateMetadataRequest, *string) (*models_pkg.GetInvoiceResponse, error)
 
     GetInvoices (*int64, *int64, *string, *string, *string, *time.Time, *time.Time, *string, *time.Time, *time.Time, *string) (*models_pkg.ListInvoicesResponse, error)
 

--- a/src/pagarmecoreapi_lib/models_pkg/Models.go
+++ b/src/pagarmecoreapi_lib/models_pkg/Models.go
@@ -26,10 +26,13 @@ type GetCheckoutBoletoPaymentResponse struct {
 }
 
 /*
- * Structure for the custom type CreateCardOptionsRequest
+ * Structure for the custom type UpdatePriceBracketRequest
  */
-type CreateCardOptionsRequest struct {
-    VerifyCard      bool            `json:"verify_card" form:"verify_card"` //Indicates if the card should be verified before creation. If true, executes an authorization before saving the card.
+type UpdatePriceBracketRequest struct {
+    StartQuantity   int64           `json:"start_quantity" form:"start_quantity"` //Start quantity of the bracket
+    Price           int64           `json:"price" form:"price"` //Price
+    EndQuantity     *int64          `json:"end_quantity,omitempty" form:"end_quantity,omitempty"` //End quantity of the bracket
+    OveragePrice    *int64          `json:"overage_price,omitempty" form:"overage_price,omitempty"` //Overage price
 }
 
 /*
@@ -65,6 +68,13 @@ type PagingResponse struct {
 }
 
 /*
+ * Structure for the custom type CreateCardOptionsRequest
+ */
+type CreateCardOptionsRequest struct {
+    VerifyCard      bool            `json:"verify_card" form:"verify_card"` //Indicates if the card should be verified before creation. If true, executes an authorization before saving the card.
+}
+
+/*
  * Structure for the custom type ListTransactionsResponse
  */
 type ListTransactionsResponse struct {
@@ -90,6 +100,14 @@ type GetPlanItemResponse struct {
 }
 
 /*
+ * Structure for the custom type ListCardsResponse
+ */
+type ListCardsResponse struct {
+    Data            []*GetCardResponse `json:"data" form:"data"` //The card objects
+    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
+}
+
+/*
  * Structure for the custom type GetPhonesResponse
  */
 type GetPhonesResponse struct {
@@ -108,14 +126,6 @@ type CreateCardTokenRequest struct {
     Cvv             string          `json:"cvv" form:"cvv"` //The card's security code
     Brand           string          `json:"brand" form:"brand"` //Card brand
     Label           string          `json:"label" form:"label"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type ListCardsResponse
- */
-type ListCardsResponse struct {
-    Data            []*GetCardResponse `json:"data" form:"data"` //The card objects
-    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
 }
 
 /*
@@ -495,17 +505,6 @@ type GetCheckoutCardInstallmentOptionsResponse struct {
 }
 
 /*
- * Structure for the custom type CreatePricingSchemeRequest
- */
-type CreatePricingSchemeRequest struct {
-    SchemeType      string          `json:"scheme_type" form:"scheme_type"` //Scheme type
-    PriceBrackets   []*CreatePriceBracketRequest `json:"price_brackets" form:"price_brackets"` //Price brackets
-    Price           *int64          `json:"price,omitempty" form:"price,omitempty"` //Price
-    MinimumPrice    *int64          `json:"minimum_price,omitempty" form:"minimum_price,omitempty"` //Minimum price
-    Percentage      *float64        `json:"percentage,omitempty" form:"percentage,omitempty"` //percentual value used in pricing_scheme Percent
-}
-
-/*
  * Structure for the custom type CreateCancelSubscriptionRequest
  */
 type CreateCancelSubscriptionRequest struct {
@@ -558,6 +557,17 @@ type CreateBankTransferPaymentRequest struct {
 }
 
 /*
+ * Structure for the custom type CreatePricingSchemeRequest
+ */
+type CreatePricingSchemeRequest struct {
+    SchemeType      string          `json:"scheme_type" form:"scheme_type"` //Scheme type
+    PriceBrackets   []*CreatePriceBracketRequest `json:"price_brackets" form:"price_brackets"` //Price brackets
+    Price           *int64          `json:"price,omitempty" form:"price,omitempty"` //Price
+    MinimumPrice    *int64          `json:"minimum_price,omitempty" form:"minimum_price,omitempty"` //Minimum price
+    Percentage      *float64        `json:"percentage,omitempty" form:"percentage,omitempty"` //percentual value used in pricing_scheme Percent
+}
+
+/*
  * Structure for the custom type CreatePhonesRequest
  */
 type CreatePhonesRequest struct {
@@ -592,14 +602,6 @@ type UpdateChargeDueDateRequest struct {
 }
 
 /*
- * Structure for the custom type ListSubscriptionItemsResponse
- */
-type ListSubscriptionItemsResponse struct {
-    Data            []*GetSubscriptionItemResponse `json:"data" form:"data"` //The subscription items
-    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
-}
-
-/*
  * Structure for the custom type CreateAccessTokenRequest
  */
 type CreateAccessTokenRequest struct {
@@ -630,6 +632,14 @@ type GetVoucherTransactionResponse struct {
     AcquirerReturnCode        string          `json:"acquirer_return_code" form:"acquirer_return_code"` //Acquirer return code
     OperationType             string          `json:"operation_type" form:"operation_type"` //Operation type
     Card                      GetCardResponse `json:"card" form:"card"` //Card data
+}
+
+/*
+ * Structure for the custom type ListSubscriptionItemsResponse
+ */
+type ListSubscriptionItemsResponse struct {
+    Data            []*GetSubscriptionItemResponse `json:"data" form:"data"` //The subscription items
+    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
 }
 
 /*
@@ -703,33 +713,6 @@ type CreateAddressRequest struct {
 }
 
 /*
- * Structure for the custom type UpdatePriceBracketRequest
- */
-type UpdatePriceBracketRequest struct {
-    StartQuantity   int64           `json:"start_quantity" form:"start_quantity"` //Start quantity of the bracket
-    Price           int64           `json:"price" form:"price"` //Price
-    EndQuantity     *int64          `json:"end_quantity,omitempty" form:"end_quantity,omitempty"` //End quantity of the bracket
-    OveragePrice    *int64          `json:"overage_price,omitempty" form:"overage_price,omitempty"` //Overage price
-}
-
-/*
- * Structure for the custom type GetSellerResponse
- */
-type GetSellerResponse struct {
-    Id              string          `json:"id" form:"id"` //Identification
-    Name            string          `json:"name" form:"name"` //TODO: Write general description for this field
-    Code            string          `json:"code" form:"code"` //TODO: Write general description for this field
-    Document        string          `json:"document" form:"document"` //TODO: Write general description for this field
-    Description     string          `json:"description" form:"description"` //Description
-    Status          string          `json:"Status" form:"Status"` //Status
-    CreatedAt       string          `json:"CreatedAt" form:"CreatedAt"` //Creation date
-    UpdatedAt       string          `json:"UpdatedAt" form:"UpdatedAt"` //Updated date
-    Address         GetAddressResponse `json:"Address" form:"Address"` //Address
-    Metadata        map[string]string `json:"Metadata" form:"Metadata"` //Metadata
-    DeletedAt       *string         `json:"DeletedAt,omitempty" form:"DeletedAt,omitempty"` //Deleted date
-}
-
-/*
  * Structure for the custom type CreateSubscriptionItemRequest
  */
 type CreateSubscriptionItemRequest struct {
@@ -742,19 +725,6 @@ type CreateSubscriptionItemRequest struct {
     Cycles          *int64          `json:"cycles,omitempty" form:"cycles,omitempty"` //Number of cycles which the item will be charged
     Quantity        *int64          `json:"quantity,omitempty" form:"quantity,omitempty"` //Quantity of items
     MinimumPrice    *int64          `json:"minimum_price,omitempty" form:"minimum_price,omitempty"` //Minimum price
-}
-
-/*
- * Structure for the custom type GetSellersRequest
- */
-type GetSellersRequest struct {
-    Name            string          `json:"name" form:"name"` //TODO: Write general description for this field
-    Document        string          `json:"document" form:"document"` //TODO: Write general description for this field
-    Code            string          `json:"code" form:"code"` //TODO: Write general description for this field
-    Status          string          `json:"status" form:"status"` //TODO: Write general description for this field
-    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
-    CreatedSince    *string         `json:"created_Since,omitempty" form:"created_Since,omitempty"` //TODO: Write general description for this field
-    CreatedUntil    *string         `json:"created_Until,omitempty" form:"created_Until,omitempty"` //TODO: Write general description for this field
 }
 
 /*
@@ -799,14 +769,6 @@ type CreateDeviceRequest struct {
  */
 type UpdateSubscriptionAffiliationIdRequest struct {
     GatewayAffiliationId   string          `json:"gateway_affiliation_id" form:"gateway_affiliation_id"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type ListSellerResponse
- */
-type ListSellerResponse struct {
-    Data            []*GetSellerResponse `json:"data" form:"data"` //The order object
-    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
 }
 
 /*
@@ -889,6 +851,25 @@ type UpdateRecipientRequest struct {
 }
 
 /*
+ * Structure for the custom type GetGatewayRecipientResponse
+ */
+type GetGatewayRecipientResponse struct {
+    Gateway         string          `json:"gateway" form:"gateway"` //Gateway name
+    Status          string          `json:"status" form:"status"` //Status of the recipient on the gateway
+    Pgid            string          `json:"pgid" form:"pgid"` //Recipient id on the gateway
+    CreatedAt       string          `json:"created_at" form:"created_at"` //Creation date
+    UpdatedAt       string          `json:"updated_at" form:"updated_at"` //Last update date
+}
+
+/*
+ * Structure for the custom type ListIncrementsResponse
+ */
+type ListIncrementsResponse struct {
+    Data            []*GetIncrementResponse `json:"data" form:"data"` //The Increments response
+    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
+}
+
+/*
  * Structure for the custom type CreateAnticipationRequest
  */
 type CreateAnticipationRequest struct {
@@ -950,25 +931,6 @@ type GetCardResponse struct {
     DeletedAt        *time.Time      `json:"deleted_at,omitempty" form:"deleted_at,omitempty"` //TODO: Write general description for this field
     FirstSixDigits   string          `json:"first_six_digits" form:"first_six_digits"` //First six digits
     Label            string          `json:"label" form:"label"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type GetGatewayRecipientResponse
- */
-type GetGatewayRecipientResponse struct {
-    Gateway         string          `json:"gateway" form:"gateway"` //Gateway name
-    Status          string          `json:"status" form:"status"` //Status of the recipient on the gateway
-    Pgid            string          `json:"pgid" form:"pgid"` //Recipient id on the gateway
-    CreatedAt       string          `json:"created_at" form:"created_at"` //Creation date
-    UpdatedAt       string          `json:"updated_at" form:"updated_at"` //Last update date
-}
-
-/*
- * Structure for the custom type ListIncrementsResponse
- */
-type ListIncrementsResponse struct {
-    Data            []*GetIncrementResponse `json:"data" form:"data"` //The Increments response
-    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
 }
 
 /*
@@ -1067,6 +1029,14 @@ type GetBoletoTransactionResponse struct {
 }
 
 /*
+ * Structure for the custom type GetLocationResponse
+ */
+type GetLocationResponse struct {
+    Latitude        string          `json:"latitude" form:"latitude"` //Latitude
+    Longitude       string          `json:"longitude" form:"longitude"` //Longitude
+}
+
+/*
  * Structure for the custom type GetSubscriptionItemResponse
  */
 type GetSubscriptionItemResponse struct {
@@ -1107,27 +1077,12 @@ type GetDebitCardTransactionResponse struct {
 }
 
 /*
- * Structure for the custom type GetLocationResponse
- */
-type GetLocationResponse struct {
-    Latitude        string          `json:"latitude" form:"latitude"` //Latitude
-    Longitude       string          `json:"longitude" form:"longitude"` //Longitude
-}
-
-/*
  * Structure for the custom type CreateTransferSettingsRequest
  */
 type CreateTransferSettingsRequest struct {
     TransferEnabled   bool            `json:"transfer_enabled" form:"transfer_enabled"` //TODO: Write general description for this field
     TransferInterval  string          `json:"transfer_interval" form:"transfer_interval"` //TODO: Write general description for this field
     TransferDay       int64           `json:"transfer_day" form:"transfer_day"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type GetGatewayErrorResponse
- */
-type GetGatewayErrorResponse struct {
-    Message         string          `json:"message" form:"message"` //The message error
 }
 
 /*
@@ -1139,19 +1094,10 @@ type CreateTransferRequest struct {
 }
 
 /*
- * Structure for the custom type GetBillingAddressResponse
+ * Structure for the custom type GetGatewayErrorResponse
  */
-type GetBillingAddressResponse struct {
-    Street          string          `json:"street" form:"street"` //TODO: Write general description for this field
-    Number          string          `json:"number" form:"number"` //TODO: Write general description for this field
-    ZipCode         string          `json:"zip_code" form:"zip_code"` //TODO: Write general description for this field
-    Neighborhood    string          `json:"neighborhood" form:"neighborhood"` //TODO: Write general description for this field
-    City            string          `json:"city" form:"city"` //TODO: Write general description for this field
-    State           string          `json:"state" form:"state"` //TODO: Write general description for this field
-    Country         string          `json:"country" form:"country"` //TODO: Write general description for this field
-    Complement      string          `json:"complement" form:"complement"` //TODO: Write general description for this field
-    Line1           string          `json:"line_1" form:"line_1"` //Line 1 for address
-    Line2           string          `json:"line_2" form:"line_2"` //Line 2 for address
+type GetGatewayErrorResponse struct {
+    Message         string          `json:"message" form:"message"` //The message error
 }
 
 /*
@@ -1183,29 +1129,10 @@ type CreatePaymentAuthenticationRequest struct {
 }
 
 /*
- * Structure for the custom type CreateIncrementRequest
- */
-type CreateIncrementRequest struct {
-    Value           float64         `json:"value" form:"value"` //The increment value
-    IncrementType   string          `json:"increment_type" form:"increment_type"` //Increment type. Can be either flat or percentage.
-    ItemId          string          `json:"item_id" form:"item_id"` //The item where the increment will be applied
-    Cycles          *int64          `json:"cycles,omitempty" form:"cycles,omitempty"` //Number of cycles that the increment will be applied
-    Description     *string         `json:"description,omitempty" form:"description,omitempty"` //Description
-}
-
-/*
  * Structure for the custom type UpdateInvoiceStatusRequest
  */
 type UpdateInvoiceStatusRequest struct {
     Status          string          `json:"status" form:"status"` //Status
-}
-
-/*
- * Structure for the custom type GetAnticipationLimitResponse
- */
-type GetAnticipationLimitResponse struct {
-    Amount           int64           `json:"amount" form:"amount"` //Amount
-    AnticipationFee  int64           `json:"anticipation_fee" form:"anticipation_fee"` //Anticipation fee
 }
 
 /*
@@ -1271,6 +1198,14 @@ type CreateApplePayRequest struct {
     Header              CreateApplePayHeaderRequest `json:"header" form:"header"` //The ApplePay header request
     Signature           string          `json:"signature" form:"signature"` //Detached PKCS #7 signature, Base64 encoded as string
     MerchantIdentifier  string          `json:"merchant_identifier" form:"merchant_identifier"` //ApplePay Merchant identifier
+}
+
+/*
+ * Structure for the custom type GetAnticipationLimitResponse
+ */
+type GetAnticipationLimitResponse struct {
+    Amount           int64           `json:"amount" form:"amount"` //Amount
+    AnticipationFee  int64           `json:"anticipation_fee" form:"anticipation_fee"` //Anticipation fee
 }
 
 /*
@@ -1361,32 +1296,6 @@ type CreateApplePayHeaderRequest struct {
 }
 
 /*
- * Structure for the custom type CreateSellerRequest
- */
-type CreateSellerRequest struct {
-    Name            string          `json:"name" form:"name"` //Name
-    Code            *string         `json:"code,omitempty" form:"code,omitempty"` //Seller's code identification
-    Description     *string         `json:"description,omitempty" form:"description,omitempty"` //Description
-    Document        *string         `json:"document,omitempty" form:"document,omitempty"` //Document number (individual / company)
-    Address         *CreateAddressRequest `json:"address,omitempty" form:"address,omitempty"` //Address
-    Type            *string         `json:"type,omitempty" form:"type,omitempty"` //Person type (individual / company)
-    Metadata        map[string]string `json:"metadata" form:"metadata"` //Metadata
-}
-
-/*
- * Structure for the custom type GetTransferResponse
- */
-type GetTransferResponse struct {
-    Id              string          `json:"id" form:"id"` //Id
-    Amount          int64           `json:"amount" form:"amount"` //Transfer amount
-    Status          string          `json:"status" form:"status"` //Transfer status
-    CreatedAt       *time.Time      `json:"created_at" form:"created_at"` //Transfer creation date
-    UpdatedAt       *time.Time      `json:"updated_at" form:"updated_at"` //Transfer last update date
-    BankAccount     GetBankAccountResponse `json:"bank_account" form:"bank_account"` //Bank account
-    Metadata        map[string]string `json:"metadata" form:"metadata"` //Metadata
-}
-
-/*
  * Structure for the custom type CreateLocationRequest
  */
 type CreateLocationRequest struct {
@@ -1443,6 +1352,19 @@ type CreateRecipientRequest struct {
     TransferSettings     *CreateTransferSettingsRequest `json:"transfer_settings,omitempty" form:"transfer_settings,omitempty"` //Receiver Transfer Information
     Code                 string          `json:"code" form:"code"` //Recipient code
     PaymentMode          string          `json:"payment_mode" form:"payment_mode"` //Payment mode
+}
+
+/*
+ * Structure for the custom type GetTransferResponse
+ */
+type GetTransferResponse struct {
+    Id              string          `json:"id" form:"id"` //Id
+    Amount          int64           `json:"amount" form:"amount"` //Transfer amount
+    Status          string          `json:"status" form:"status"` //Transfer status
+    CreatedAt       *time.Time      `json:"created_at" form:"created_at"` //Transfer creation date
+    UpdatedAt       *time.Time      `json:"updated_at" form:"updated_at"` //Transfer last update date
+    BankAccount     GetBankAccountResponse `json:"bank_account" form:"bank_account"` //Bank account
+    Metadata        map[string]string `json:"metadata" form:"metadata"` //Metadata
 }
 
 /*
@@ -1514,20 +1436,6 @@ type UpdateRecipientBankAccountRequest struct {
 }
 
 /*
- * Structure for the custom type UpdateSellerRequest
- */
-type UpdateSellerRequest struct {
-    Name            string          `json:"name" form:"name"` //Seller name
-    Code            string          `json:"code" form:"code"` //Seller code
-    Description     string          `json:"description" form:"description"` //Seller description
-    Document        string          `json:"document" form:"document"` //Seller document CPF or CNPJ
-    Status          string          `json:"status" form:"status"` //TODO: Write general description for this field
-    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
-    Address         CreateAddressRequest `json:"address" form:"address"` //TODO: Write general description for this field
-    Metadata        map[string]string `json:"metadata" form:"metadata"` //TODO: Write general description for this field
-}
-
-/*
  * Structure for the custom type UpdateTransferSettingsRequest
  */
 type UpdateTransferSettingsRequest struct {
@@ -1537,99 +1445,30 @@ type UpdateTransferSettingsRequest struct {
 }
 
 /*
- * Structure for the custom type CreateCancelChargeRequest
+ * Structure for the custom type GetBillingAddressResponse
  */
-type CreateCancelChargeRequest struct {
-    Amount              *int64          `json:"amount,omitempty" form:"amount,omitempty"` //The amount that will be canceled.
-    SplitRules          []*CreateCancelChargeSplitRulesRequest `json:"split_rules,omitempty" form:"split_rules,omitempty"` //The split rules request
-    Split               []*CreateSplitRequest `json:"split,omitempty" form:"split,omitempty"` //Splits
-    OperationReference  string          `json:"operation_reference" form:"operation_reference"` //TODO: Write general description for this field
+type GetBillingAddressResponse struct {
+    Street          string          `json:"street" form:"street"` //TODO: Write general description for this field
+    Number          string          `json:"number" form:"number"` //TODO: Write general description for this field
+    ZipCode         string          `json:"zip_code" form:"zip_code"` //TODO: Write general description for this field
+    Neighborhood    string          `json:"neighborhood" form:"neighborhood"` //TODO: Write general description for this field
+    City            string          `json:"city" form:"city"` //TODO: Write general description for this field
+    State           string          `json:"state" form:"state"` //TODO: Write general description for this field
+    Country         string          `json:"country" form:"country"` //TODO: Write general description for this field
+    Complement      string          `json:"complement" form:"complement"` //TODO: Write general description for this field
+    Line1           string          `json:"line_1" form:"line_1"` //Line 1 for address
+    Line2           string          `json:"line_2" form:"line_2"` //Line 2 for address
 }
 
 /*
- * Structure for the custom type UpdateSubscriptionStartAtRequest
+ * Structure for the custom type CreateIncrementRequest
  */
-type UpdateSubscriptionStartAtRequest struct {
-    StartAt         *time.Time      `json:"start_at" form:"start_at"` //The date when the subscription periods will start
-}
-
-/*
- * Structure for the custom type CreateTransactionReportFileRequest
- */
-type CreateTransactionReportFileRequest struct {
-    Name            string          `json:"name" form:"name"` //TODO: Write general description for this field
-    StartAt         *time.Time      `json:"start_at,omitempty" form:"start_at,omitempty"` //TODO: Write general description for this field
-    EndAt           *string         `json:"end_at,omitempty" form:"end_at,omitempty"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type CreateCardRequest
- */
-type CreateCardRequest struct {
-    Number             string          `json:"number" form:"number"` //Credit card number
-    HolderName         string          `json:"holder_name" form:"holder_name"` //Holder name, as written on the card
-    ExpMonth           int64           `json:"exp_month" form:"exp_month"` //The expiration month
-    ExpYear            int64           `json:"exp_year" form:"exp_year"` //The expiration year, that can be informed with 2 or 4 digits
-    Cvv                string          `json:"cvv" form:"cvv"` //The card's security code
-    BillingAddress     CreateAddressRequest `json:"billing_address" form:"billing_address"` //Card's billing address
-    Brand              string          `json:"brand" form:"brand"` //Card brand
-    BillingAddressId   string          `json:"billing_address_id" form:"billing_address_id"` //The address id for the billing address
-    Metadata           map[string]string `json:"metadata" form:"metadata"` //Metadata
-    Type               string          `json:"type" form:"type"` //Card type
-    Options            CreateCardOptionsRequest `json:"options" form:"options"` //Options for creating the card
-    HolderDocument     *string         `json:"holder_document,omitempty" form:"holder_document,omitempty"` //Document number for the card's holder
-    PrivateLabel       bool            `json:"private_label" form:"private_label"` //Indicates whether it is a private label card
-    Label              string          `json:"label" form:"label"` //TODO: Write general description for this field
-    Id                 *string         `json:"id,omitempty" form:"id,omitempty"` //Identifier
-    Token              *string         `json:"token,omitempty" form:"token,omitempty"` //token identifier
-}
-
-/*
- * Structure for the custom type CreateEmvDataDukptDecryptRequest
- */
-type CreateEmvDataDukptDecryptRequest struct {
-    Ksn             string          `json:"ksn" form:"ksn"` //Key serial number
-}
-
-/*
- * Structure for the custom type GetWithdrawTargetResponse
- */
-type GetWithdrawTargetResponse struct {
-    TargetId        string          `json:"target_id" form:"target_id"` //TODO: Write general description for this field
-    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type GetChargesSummaryResponse
- */
-type GetChargesSummaryResponse struct {
-    Total           int64           `json:"total" form:"total"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type CreatePrivateLabelPaymentRequest
- */
-type CreatePrivateLabelPaymentRequest struct {
-    Installments           *int64          `json:"installments,omitempty" form:"installments,omitempty"` //Number of installments
-    StatementDescriptor    *string         `json:"statement_descriptor,omitempty" form:"statement_descriptor,omitempty"` //The text that will be shown on the private label's statement
-    Card                   *CreateCardRequest `json:"card,omitempty" form:"card,omitempty"` //Card data
-    CardId                 *string         `json:"card_id,omitempty" form:"card_id,omitempty"` //The Card id
-    CardToken              *string         `json:"card_token,omitempty" form:"card_token,omitempty"` //TODO: Write general description for this field
-    Recurrence             *bool           `json:"recurrence,omitempty" form:"recurrence,omitempty"` //Indicates a recurrence
-    Capture                *bool           `json:"capture,omitempty" form:"capture,omitempty"` //Indicates if the operation should be only authorization or auth and capture.
-    ExtendedLimitEnabled   *bool           `json:"extended_limit_enabled,omitempty" form:"extended_limit_enabled,omitempty"` //Indicates whether the extended label (private label) is enabled
-    ExtendedLimitCode      *string         `json:"extended_limit_code,omitempty" form:"extended_limit_code,omitempty"` //Extended Limit Code
-}
-
-/*
- * Structure for the custom type UpdateAutomaticAnticipationSettingsRequest
- */
-type UpdateAutomaticAnticipationSettingsRequest struct {
-    Enabled           *bool           `json:"enabled,omitempty" form:"enabled,omitempty"` //TODO: Write general description for this field
-    Type              *string         `json:"type,omitempty" form:"type,omitempty"` //TODO: Write general description for this field
-    VolumePercentage  *int64          `json:"volume_percentage,omitempty" form:"volume_percentage,omitempty"` //TODO: Write general description for this field
-    Delay             *int64          `json:"delay,omitempty" form:"delay,omitempty"` //TODO: Write general description for this field
-    Days              *int64          `json:"days,omitempty" form:"days,omitempty"` //TODO: Write general description for this field
+type CreateIncrementRequest struct {
+    Value           float64         `json:"value" form:"value"` //The increment value
+    IncrementType   string          `json:"increment_type" form:"increment_type"` //Increment type. Can be either flat or percentage.
+    ItemId          string          `json:"item_id" form:"item_id"` //The item where the increment will be applied
+    Cycles          *int64          `json:"cycles,omitempty" form:"cycles,omitempty"` //Number of cycles that the increment will be applied
+    Description     *string         `json:"description,omitempty" form:"description,omitempty"` //Description
 }
 
 /*
@@ -1641,12 +1480,13 @@ type CreateCashPaymentRequest struct {
 }
 
 /*
- * Structure for the custom type CreateConfirmPaymentRequest
+ * Structure for the custom type CreateCancelChargeRequest
  */
-type CreateConfirmPaymentRequest struct {
-    Description     string          `json:"description" form:"description"` //Description
-    Amount          *int64          `json:"Amount,omitempty" form:"Amount,omitempty"` //Amount
-    Code            string          `json:"Code" form:"Code"` //Code reference
+type CreateCancelChargeRequest struct {
+    Amount              *int64          `json:"amount,omitempty" form:"amount,omitempty"` //The amount that will be canceled.
+    SplitRules          []*CreateCancelChargeSplitRulesRequest `json:"split_rules,omitempty" form:"split_rules,omitempty"` //The split rules request
+    Split               []*CreateSplitRequest `json:"split,omitempty" form:"split,omitempty"` //Splits
+    OperationReference  string          `json:"operation_reference" form:"operation_reference"` //TODO: Write general description for this field
 }
 
 /*
@@ -1696,6 +1536,166 @@ type CreateTransfer struct {
     SourceId        string          `json:"source_id" form:"source_id"` //TODO: Write general description for this field
     TargetId        string          `json:"target_id" form:"target_id"` //TODO: Write general description for this field
     Metadata        *[]string       `json:"metadata,omitempty" form:"metadata,omitempty"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type CreateTransactionReportFileRequest
+ */
+type CreateTransactionReportFileRequest struct {
+    Name            string          `json:"name" form:"name"` //TODO: Write general description for this field
+    StartAt         *time.Time      `json:"start_at,omitempty" form:"start_at,omitempty"` //TODO: Write general description for this field
+    EndAt           *string         `json:"end_at,omitempty" form:"end_at,omitempty"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type CreateCardRequest
+ */
+type CreateCardRequest struct {
+    Number             string          `json:"number" form:"number"` //Credit card number
+    HolderName         string          `json:"holder_name" form:"holder_name"` //Holder name, as written on the card
+    ExpMonth           int64           `json:"exp_month" form:"exp_month"` //The expiration month
+    ExpYear            int64           `json:"exp_year" form:"exp_year"` //The expiration year, that can be informed with 2 or 4 digits
+    Cvv                string          `json:"cvv" form:"cvv"` //The card's security code
+    BillingAddress     CreateAddressRequest `json:"billing_address" form:"billing_address"` //Card's billing address
+    Brand              string          `json:"brand" form:"brand"` //Card brand
+    BillingAddressId   string          `json:"billing_address_id" form:"billing_address_id"` //The address id for the billing address
+    Metadata           map[string]string `json:"metadata" form:"metadata"` //Metadata
+    Type               string          `json:"type" form:"type"` //Card type
+    Options            CreateCardOptionsRequest `json:"options" form:"options"` //Options for creating the card
+    HolderDocument     *string         `json:"holder_document,omitempty" form:"holder_document,omitempty"` //Document number for the card's holder
+    PrivateLabel       bool            `json:"private_label" form:"private_label"` //Indicates whether it is a private label card
+    Label              string          `json:"label" form:"label"` //TODO: Write general description for this field
+    Id                 *string         `json:"id,omitempty" form:"id,omitempty"` //Identifier
+    Token              *string         `json:"token,omitempty" form:"token,omitempty"` //token identifier
+}
+
+/*
+ * Structure for the custom type CreateEmvDataDukptDecryptRequest
+ */
+type CreateEmvDataDukptDecryptRequest struct {
+    Ksn             string          `json:"ksn" form:"ksn"` //Key serial number
+}
+
+/*
+ * Structure for the custom type GetWithdrawTargetResponse
+ */
+type GetWithdrawTargetResponse struct {
+    TargetId        string          `json:"target_id" form:"target_id"` //TODO: Write general description for this field
+    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type CreateCancelChargeSplitRulesRequest
+ */
+type CreateCancelChargeSplitRulesRequest struct {
+    Id              string          `json:"id" form:"id"` //The split rule gateway id
+    Amount          int64           `json:"Amount" form:"Amount"` //The split rule amount
+    Type            string          `json:"type" form:"type"` //The amount type (flat ou percentage)
+}
+
+/*
+ * Structure for the custom type UpdateSubscriptionStartAtRequest
+ */
+type UpdateSubscriptionStartAtRequest struct {
+    StartAt         *time.Time      `json:"start_at" form:"start_at"` //The date when the subscription periods will start
+}
+
+/*
+ * Structure for the custom type CreatePixPaymentRequest
+ */
+type CreatePixPaymentRequest struct {
+    ExpiresAt              *time.Time      `json:"expires_at,omitempty" form:"expires_at,omitempty"` //Datetime when pix payment will expire
+    ExpiresIn              *int64          `json:"expires_in,omitempty" form:"expires_in,omitempty"` //Seconds until pix payment expires
+    AdditionalInformation  []*PixAdditionalInformation `json:"additional_information,omitempty" form:"additional_information,omitempty"` //Pix additional information
+}
+
+/*
+ * Structure for the custom type GetChargesSummaryResponse
+ */
+type GetChargesSummaryResponse struct {
+    Total           int64           `json:"total" form:"total"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type CreatePrivateLabelPaymentRequest
+ */
+type CreatePrivateLabelPaymentRequest struct {
+    Installments           *int64          `json:"installments,omitempty" form:"installments,omitempty"` //Number of installments
+    StatementDescriptor    *string         `json:"statement_descriptor,omitempty" form:"statement_descriptor,omitempty"` //The text that will be shown on the private label's statement
+    Card                   *CreateCardRequest `json:"card,omitempty" form:"card,omitempty"` //Card data
+    CardId                 *string         `json:"card_id,omitempty" form:"card_id,omitempty"` //The Card id
+    CardToken              *string         `json:"card_token,omitempty" form:"card_token,omitempty"` //TODO: Write general description for this field
+    Recurrence             *bool           `json:"recurrence,omitempty" form:"recurrence,omitempty"` //Indicates a recurrence
+    Capture                *bool           `json:"capture,omitempty" form:"capture,omitempty"` //Indicates if the operation should be only authorization or auth and capture.
+    ExtendedLimitEnabled   *bool           `json:"extended_limit_enabled,omitempty" form:"extended_limit_enabled,omitempty"` //Indicates whether the extended label (private label) is enabled
+    ExtendedLimitCode      *string         `json:"extended_limit_code,omitempty" form:"extended_limit_code,omitempty"` //Extended Limit Code
+}
+
+/*
+ * Structure for the custom type UpdateAutomaticAnticipationSettingsRequest
+ */
+type UpdateAutomaticAnticipationSettingsRequest struct {
+    Enabled           *bool           `json:"enabled,omitempty" form:"enabled,omitempty"` //TODO: Write general description for this field
+    Type              *string         `json:"type,omitempty" form:"type,omitempty"` //TODO: Write general description for this field
+    VolumePercentage  *int64          `json:"volume_percentage,omitempty" form:"volume_percentage,omitempty"` //TODO: Write general description for this field
+    Delay             *int64          `json:"delay,omitempty" form:"delay,omitempty"` //TODO: Write general description for this field
+    Days              *int64          `json:"days,omitempty" form:"days,omitempty"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type GetSplitResponse
+ */
+type GetSplitResponse struct {
+    Type            string          `json:"type" form:"type"` //Type
+    Amount          int64           `json:"amount" form:"amount"` //Amount
+    Recipient       *GetRecipientResponse `json:"recipient,omitempty" form:"recipient,omitempty"` //Recipient
+    GatewayId       string          `json:"gateway_id" form:"gateway_id"` //The split rule gateway id
+    Options         *GetSplitOptionsResponse `json:"options,omitempty" form:"options,omitempty"` //TODO: Write general description for this field
+    Id              string          `json:"id" form:"id"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type ListTransactionsFilesResponse
+ */
+type ListTransactionsFilesResponse struct {
+    Data            []*GetTransactionReportFileResponse `json:"data" form:"data"` //TODO: Write general description for this field
+    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
+}
+
+/*
+ * Structure for the custom type CreateEmvDataTlvDecryptRequest
+ */
+type CreateEmvDataTlvDecryptRequest struct {
+    Tag             string          `json:"tag" form:"tag"` //Emv tag
+    Lenght          string          `json:"lenght" form:"lenght"` //Emv lenght
+    Value           string          `json:"value" form:"value"` //Emv value
+}
+
+/*
+ * Structure for the custom type CreateEmvDecryptRequest
+ */
+type CreateEmvDecryptRequest struct {
+    IccData              string          `json:"icc_data" form:"icc_data"` //TODO: Write general description for this field
+    CardSequenceNumber   string          `json:"card_sequence_number" form:"card_sequence_number"` //TODO: Write general description for this field
+    Data                 CreateEmvDataDecryptRequest `json:"data" form:"data"` //TODO: Write general description for this field
+    Poi                  *CreateCardPaymentContactlessPOIRequest `json:"poi,omitempty" form:"poi,omitempty"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type GetWithdrawSourceResponse
+ */
+type GetWithdrawSourceResponse struct {
+    SourceId        string          `json:"source_id" form:"source_id"` //TODO: Write general description for this field
+    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
+}
+
+/*
+ * Structure for the custom type CreateConfirmPaymentRequest
+ */
+type CreateConfirmPaymentRequest struct {
+    Description     string          `json:"description" form:"description"` //Description
+    Amount          *int64          `json:"Amount,omitempty" form:"Amount,omitempty"` //Amount
+    Code            string          `json:"Code" form:"Code"` //Code reference
 }
 
 /*
@@ -1752,76 +1752,18 @@ type CreateAutomaticAnticipationSettingsRequest struct {
 }
 
 /*
- * Structure for the custom type CreateCancelChargeSplitRulesRequest
- */
-type CreateCancelChargeSplitRulesRequest struct {
-    Id              string          `json:"id" form:"id"` //The split rule gateway id
-    Amount          int64           `json:"Amount" form:"Amount"` //The split rule amount
-    Type            string          `json:"type" form:"type"` //The amount type (flat ou percentage)
-}
-
-/*
- * Structure for the custom type GetSplitResponse
- */
-type GetSplitResponse struct {
-    Type            string          `json:"type" form:"type"` //Type
-    Amount          int64           `json:"amount" form:"amount"` //Amount
-    Recipient       *GetRecipientResponse `json:"recipient,omitempty" form:"recipient,omitempty"` //Recipient
-    GatewayId       string          `json:"gateway_id" form:"gateway_id"` //The split rule gateway id
-    Options         *GetSplitOptionsResponse `json:"options,omitempty" form:"options,omitempty"` //TODO: Write general description for this field
-    Id              string          `json:"id" form:"id"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type CreatePixPaymentRequest
- */
-type CreatePixPaymentRequest struct {
-    ExpiresAt              *time.Time      `json:"expires_at,omitempty" form:"expires_at,omitempty"` //Datetime when pix payment will expire
-    ExpiresIn              *int64          `json:"expires_in,omitempty" form:"expires_in,omitempty"` //Seconds until pix payment expires
-    AdditionalInformation  []*PixAdditionalInformation `json:"additional_information,omitempty" form:"additional_information,omitempty"` //Pix additional information
-}
-
-/*
- * Structure for the custom type ListTransactionsFilesResponse
- */
-type ListTransactionsFilesResponse struct {
-    Data            []*GetTransactionReportFileResponse `json:"data" form:"data"` //TODO: Write general description for this field
-    Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
-}
-
-/*
- * Structure for the custom type CreateEmvDataTlvDecryptRequest
- */
-type CreateEmvDataTlvDecryptRequest struct {
-    Tag             string          `json:"tag" form:"tag"` //Emv tag
-    Lenght          string          `json:"lenght" form:"lenght"` //Emv lenght
-    Value           string          `json:"value" form:"value"` //Emv value
-}
-
-/*
- * Structure for the custom type CreateEmvDecryptRequest
- */
-type CreateEmvDecryptRequest struct {
-    IccData              string          `json:"icc_data" form:"icc_data"` //TODO: Write general description for this field
-    CardSequenceNumber   string          `json:"card_sequence_number" form:"card_sequence_number"` //TODO: Write general description for this field
-    Data                 CreateEmvDataDecryptRequest `json:"data" form:"data"` //TODO: Write general description for this field
-    Poi                  *CreateCardPaymentContactlessPOIRequest `json:"poi,omitempty" form:"poi,omitempty"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type GetWithdrawSourceResponse
- */
-type GetWithdrawSourceResponse struct {
-    SourceId        string          `json:"source_id" form:"source_id"` //TODO: Write general description for this field
-    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
-}
-
-/*
  * Structure for the custom type GetCashTransactionResponse
  */
 type GetCashTransactionResponse struct {
     GetTransactionResponse // Anonymous member to emulate model inheritence
     Description     string          `json:"description" form:"description"` //Description
+}
+
+/*
+ * Structure for the custom type UpdateSubscriptionMinimumPriceRequest
+ */
+type UpdateSubscriptionMinimumPriceRequest struct {
+    MinimumPrice    *int64          `json:"minimum_price,omitempty" form:"minimum_price,omitempty"` //Valor mínimo da assinatura
 }
 
 /*
@@ -1883,21 +1825,12 @@ type GetBankAccountResponse struct {
 }
 
 /*
- * Structure for the custom type UpdateSubscriptionMinimumPriceRequest
- */
-type UpdateSubscriptionMinimumPriceRequest struct {
-    MinimumPrice    *int64          `json:"minimum_price,omitempty" form:"minimum_price,omitempty"` //Valor mínimo da assinatura
-}
-
-/*
  * Structure for the custom type CreateOrderItemRequest
  */
 type CreateOrderItemRequest struct {
     Amount          int64           `json:"amount" form:"amount"` //Amount
     Description     string          `json:"description" form:"description"` //Description
     Quantity        int64           `json:"quantity" form:"quantity"` //Quantity
-    Seller          *CreateSellerRequest `json:"seller,omitempty" form:"seller,omitempty"` //Item seller
-    SellerId        *string         `json:"seller_id,omitempty" form:"seller_id,omitempty"` //seller identificator
     Category        string          `json:"category" form:"category"` //Category
     Code            *string         `json:"code,omitempty" form:"code,omitempty"` //The item code passed by the client
 }
@@ -1966,6 +1899,13 @@ type GetShippingResponse struct {
 }
 
 /*
+ * Structure for the custom type UpdateCurrentCycleEndDateRequest
+ */
+type UpdateCurrentCycleEndDateRequest struct {
+    EndAt           *time.Time      `json:"end_at,omitempty" form:"end_at,omitempty"` //Current cycle end date
+}
+
+/*
  * Structure for the custom type CreateCheckoutBankTransferRequest
  */
 type CreateCheckoutBankTransferRequest struct {
@@ -2013,23 +1953,6 @@ type GetTransferTargetResponse struct {
 type ListWithdrawals struct {
     Data            []*GetWithdrawResponse `json:"data" form:"data"` //The Increments response
     Paging          PagingResponse  `json:"paging" form:"paging"` //Paging object
-}
-
-/*
- * Structure for the custom type UpdateCurrentCycleEndDateRequest
- */
-type UpdateCurrentCycleEndDateRequest struct {
-    EndAt           *time.Time      `json:"end_at,omitempty" form:"end_at,omitempty"` //Current cycle end date
-}
-
-/*
- * Structure for the custom type CreateCheckoutCreditCardPaymentRequest
- */
-type CreateCheckoutCreditCardPaymentRequest struct {
-    StatementDescriptor  *string         `json:"statement_descriptor,omitempty" form:"statement_descriptor,omitempty"` //Card invoice text descriptor
-    Installments         []*CreateCheckoutCardInstallmentOptionRequest `json:"installments,omitempty" form:"installments,omitempty"` //Payment installment options
-    Authentication       *CreatePaymentAuthenticationRequest `json:"authentication,omitempty" form:"authentication,omitempty"` //Creates payment authentication
-    Capture              *bool           `json:"capture,omitempty" form:"capture,omitempty"` //Authorize and capture?
 }
 
 /*
@@ -2105,6 +2028,57 @@ type GetAutomaticAnticipationResponse struct {
 }
 
 /*
+ * Structure for the custom type CreateCheckoutPaymentRequest
+ */
+type CreateCheckoutPaymentRequest struct {
+    AcceptedPaymentMethods         []string        `json:"accepted_payment_methods" form:"accepted_payment_methods"` //Accepted Payment Methods
+    AcceptedMultiPaymentMethods    []interface{}   `json:"accepted_multi_payment_methods" form:"accepted_multi_payment_methods"` //Accepted Multi Payment Methods
+    SuccessUrl                     string          `json:"success_url" form:"success_url"` //Success url
+    DefaultPaymentMethod           *string         `json:"default_payment_method,omitempty" form:"default_payment_method,omitempty"` //Default payment method
+    GatewayAffiliationId           *string         `json:"gateway_affiliation_id,omitempty" form:"gateway_affiliation_id,omitempty"` //Gateway Affiliation Id
+    CreditCard                     *CreateCheckoutCreditCardPaymentRequest `json:"credit_card,omitempty" form:"credit_card,omitempty"` //Credit Card payment request
+    DebitCard                      *CreateCheckoutDebitCardPaymentRequest `json:"debit_card,omitempty" form:"debit_card,omitempty"` //Debit Card payment request
+    Boleto                         *CreateCheckoutBoletoPaymentRequest `json:"boleto,omitempty" form:"boleto,omitempty"` //Boleto payment request
+    CustomerEditable               *bool           `json:"customer_editable,omitempty" form:"customer_editable,omitempty"` //Customer is editable?
+    ExpiresIn                      *int64          `json:"expires_in,omitempty" form:"expires_in,omitempty"` //Time in minutes for expiration
+    SkipCheckoutSuccessPage        bool            `json:"skip_checkout_success_page" form:"skip_checkout_success_page"` //Skip postpay success screen?
+    BillingAddressEditable         bool            `json:"billing_address_editable" form:"billing_address_editable"` //Billing Address is editable?
+    BillingAddress                 CreateAddressRequest `json:"billing_address" form:"billing_address"` //Billing Address
+    BankTransfer                   *CreateCheckoutBankTransferRequest `json:"bank_transfer,omitempty" form:"bank_transfer,omitempty"` //Bank Transfer payment request
+    AcceptedBrands                 []string        `json:"accepted_brands" form:"accepted_brands"` //Accepted Brands
+    Pix                            *CreateCheckoutPixPaymentRequest `json:"pix,omitempty" form:"pix,omitempty"` //Pix payment request
+}
+
+/*
+ * Structure for the custom type CreateCheckoutCreditCardPaymentRequest
+ */
+type CreateCheckoutCreditCardPaymentRequest struct {
+    StatementDescriptor  *string         `json:"statement_descriptor,omitempty" form:"statement_descriptor,omitempty"` //Card invoice text descriptor
+    Installments         []*CreateCheckoutCardInstallmentOptionRequest `json:"installments,omitempty" form:"installments,omitempty"` //Payment installment options
+    Authentication       *CreatePaymentAuthenticationRequest `json:"authentication,omitempty" form:"authentication,omitempty"` //Creates payment authentication
+    Capture              *bool           `json:"capture,omitempty" form:"capture,omitempty"` //Authorize and capture?
+}
+
+/*
+ * Structure for the custom type GetTransfer
+ */
+type GetTransfer struct {
+    Id                     string          `json:"id" form:"id"` //TODO: Write general description for this field
+    GatewayId              string          `json:"gateway_id" form:"gateway_id"` //TODO: Write general description for this field
+    Amount                 int64           `json:"amount" form:"amount"` //TODO: Write general description for this field
+    Status                 string          `json:"status" form:"status"` //TODO: Write general description for this field
+    CreatedAt              *time.Time      `json:"created_at" form:"created_at"` //TODO: Write general description for this field
+    UpdatedAt              *time.Time      `json:"updated_at" form:"updated_at"` //TODO: Write general description for this field
+    Metadata               *map[string]string `json:"metadata,omitempty" form:"metadata,omitempty"` //TODO: Write general description for this field
+    Fee                    *int64          `json:"fee,omitempty" form:"fee,omitempty"` //TODO: Write general description for this field
+    FundingDate            *time.Time      `json:"funding_date,omitempty" form:"funding_date,omitempty"` //TODO: Write general description for this field
+    FundingEstimatedDate   *time.Time      `json:"funding_estimated_date,omitempty" form:"funding_estimated_date,omitempty"` //TODO: Write general description for this field
+    Type                   string          `json:"type" form:"type"` //TODO: Write general description for this field
+    Source                 GetTransferSourceResponse `json:"source" form:"source"` //TODO: Write general description for this field
+    Target                 GetTransferTargetResponse `json:"target" form:"target"` //TODO: Write general description for this field
+}
+
+/*
  * Structure for the custom type CreateSplitRequest
  */
 type CreateSplitRequest struct {
@@ -2138,28 +2112,6 @@ type GetTransferSettingsResponse struct {
 }
 
 /*
- * Structure for the custom type CreateCheckoutPaymentRequest
- */
-type CreateCheckoutPaymentRequest struct {
-    AcceptedPaymentMethods         []string        `json:"accepted_payment_methods" form:"accepted_payment_methods"` //Accepted Payment Methods
-    AcceptedMultiPaymentMethods    []interface{}   `json:"accepted_multi_payment_methods" form:"accepted_multi_payment_methods"` //Accepted Multi Payment Methods
-    SuccessUrl                     string          `json:"success_url" form:"success_url"` //Success url
-    DefaultPaymentMethod           *string         `json:"default_payment_method,omitempty" form:"default_payment_method,omitempty"` //Default payment method
-    GatewayAffiliationId           *string         `json:"gateway_affiliation_id,omitempty" form:"gateway_affiliation_id,omitempty"` //Gateway Affiliation Id
-    CreditCard                     *CreateCheckoutCreditCardPaymentRequest `json:"credit_card,omitempty" form:"credit_card,omitempty"` //Credit Card payment request
-    DebitCard                      *CreateCheckoutDebitCardPaymentRequest `json:"debit_card,omitempty" form:"debit_card,omitempty"` //Debit Card payment request
-    Boleto                         *CreateCheckoutBoletoPaymentRequest `json:"boleto,omitempty" form:"boleto,omitempty"` //Boleto payment request
-    CustomerEditable               *bool           `json:"customer_editable,omitempty" form:"customer_editable,omitempty"` //Customer is editable?
-    ExpiresIn                      *int64          `json:"expires_in,omitempty" form:"expires_in,omitempty"` //Time in minutes for expiration
-    SkipCheckoutSuccessPage        bool            `json:"skip_checkout_success_page" form:"skip_checkout_success_page"` //Skip postpay success screen?
-    BillingAddressEditable         bool            `json:"billing_address_editable" form:"billing_address_editable"` //Billing Address is editable?
-    BillingAddress                 CreateAddressRequest `json:"billing_address" form:"billing_address"` //Billing Address
-    BankTransfer                   *CreateCheckoutBankTransferRequest `json:"bank_transfer,omitempty" form:"bank_transfer,omitempty"` //Bank Transfer payment request
-    AcceptedBrands                 []string        `json:"accepted_brands" form:"accepted_brands"` //Accepted Brands
-    Pix                            *CreateCheckoutPixPaymentRequest `json:"pix,omitempty" form:"pix,omitempty"` //Pix payment request
-}
-
-/*
  * Structure for the custom type CreatePeriodRequest
  */
 type CreatePeriodRequest struct {
@@ -2167,22 +2119,11 @@ type CreatePeriodRequest struct {
 }
 
 /*
- * Structure for the custom type GetTransfer
+ * Structure for the custom type GetPaymentAuthenticationResponse
  */
-type GetTransfer struct {
-    Id                     string          `json:"id" form:"id"` //TODO: Write general description for this field
-    GatewayId              string          `json:"gateway_id" form:"gateway_id"` //TODO: Write general description for this field
-    Amount                 int64           `json:"amount" form:"amount"` //TODO: Write general description for this field
-    Status                 string          `json:"status" form:"status"` //TODO: Write general description for this field
-    CreatedAt              *time.Time      `json:"created_at" form:"created_at"` //TODO: Write general description for this field
-    UpdatedAt              *time.Time      `json:"updated_at" form:"updated_at"` //TODO: Write general description for this field
-    Metadata               *map[string]string `json:"metadata,omitempty" form:"metadata,omitempty"` //TODO: Write general description for this field
-    Fee                    *int64          `json:"fee,omitempty" form:"fee,omitempty"` //TODO: Write general description for this field
-    FundingDate            *time.Time      `json:"funding_date,omitempty" form:"funding_date,omitempty"` //TODO: Write general description for this field
-    FundingEstimatedDate   *time.Time      `json:"funding_estimated_date,omitempty" form:"funding_estimated_date,omitempty"` //TODO: Write general description for this field
-    Type                   string          `json:"type" form:"type"` //TODO: Write general description for this field
-    Source                 GetTransferSourceResponse `json:"source" form:"source"` //TODO: Write general description for this field
-    Target                 GetTransferTargetResponse `json:"target" form:"target"` //TODO: Write general description for this field
+type GetPaymentAuthenticationResponse struct {
+    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
+    ThreedSecure    GetThreeDSecureResponse `json:"threed_secure" form:"threed_secure"` //3D-S payment authentication response
 }
 
 /*
@@ -2207,13 +2148,12 @@ type CreateGooglePayHeaderRequest struct {
  * Structure for the custom type GetOrderItemResponse
  */
 type GetOrderItemResponse struct {
-    Id                string          `json:"id" form:"id"` //Id
-    Amount            int64           `json:"amount" form:"amount"` //TODO: Write general description for this field
-    Description       string          `json:"description" form:"description"` //TODO: Write general description for this field
-    Quantity          int64           `json:"quantity" form:"quantity"` //TODO: Write general description for this field
-    GetSellerResponse *GetSellerResponse `json:"GetSellerResponse,omitempty" form:"GetSellerResponse,omitempty"` //Seller data
-    Category          string          `json:"category" form:"category"` //Category
-    Code              string          `json:"code" form:"code"` //Code
+    Id              string          `json:"id" form:"id"` //Id
+    Amount          int64           `json:"amount" form:"amount"` //TODO: Write general description for this field
+    Description     string          `json:"description" form:"description"` //TODO: Write general description for this field
+    Quantity        int64           `json:"quantity" form:"quantity"` //TODO: Write general description for this field
+    Category        string          `json:"category" form:"category"` //Category
+    Code            string          `json:"code" form:"code"` //Code
 }
 
 /*
@@ -2265,14 +2205,6 @@ type GetSplitOptionsResponse struct {
     Liable                bool            `json:"liable" form:"liable"` //TODO: Write general description for this field
     ChargeProcessingFee   bool            `json:"charge_processing_fee" form:"charge_processing_fee"` //TODO: Write general description for this field
     ChargeRemainderFee    string          `json:"charge_remainder_fee" form:"charge_remainder_fee"` //TODO: Write general description for this field
-}
-
-/*
- * Structure for the custom type GetPaymentAuthenticationResponse
- */
-type GetPaymentAuthenticationResponse struct {
-    Type            string          `json:"type" form:"type"` //TODO: Write general description for this field
-    ThreedSecure    GetThreeDSecureResponse `json:"threed_secure" form:"threed_secure"` //3D-S payment authentication response
 }
 
 /*

--- a/src/pagarmecoreapi_lib/orders_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/orders_pkg/Client.go
@@ -75,7 +75,7 @@ func (me *ORDERS_IMPL) GetOrders (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -111,6 +111,90 @@ func (me *ORDERS_IMPL) GetOrders (
 
     //returning the response
     var retVal *models_pkg.ListOrderResponse = &models_pkg.ListOrderResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * TODO: type endpoint description here
+ * @param    string         orderId             parameter: Required
+ * @param    *string        idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetOrderResponse response from the API call
+ */
+func (me *ORDERS_IMPL) DeleteAllOrderItems (
+            orderId string,
+            idempotencyKey *string) (*models_pkg.GetOrderResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/orders/{orderId}/items"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "orderId" : orderId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.DeleteWithAuth(_queryBuilder, headers, nil, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetOrderResponse = &models_pkg.GetOrderResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -163,7 +247,7 @@ func (me *ORDERS_IMPL) UpdateOrderItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -214,90 +298,6 @@ func (me *ORDERS_IMPL) UpdateOrderItem (
 /**
  * TODO: type endpoint description here
  * @param    string         orderId             parameter: Required
- * @param    *string        idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetOrderResponse response from the API call
- */
-func (me *ORDERS_IMPL) DeleteAllOrderItems (
-            orderId string,
-            idempotencyKey *string) (*models_pkg.GetOrderResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/orders/{orderId}/items"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "orderId" : orderId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.DeleteWithAuth(_queryBuilder, headers, nil, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetOrderResponse = &models_pkg.GetOrderResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * TODO: type endpoint description here
- * @param    string         orderId             parameter: Required
  * @param    string         itemId              parameter: Required
  * @param    *string        idempotencyKey      parameter: Optional
  * @return	Returns the *models_pkg.GetOrderItemResponse response from the API call
@@ -335,7 +335,7 @@ func (me *ORDERS_IMPL) DeleteOrderItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -421,7 +421,7 @@ func (me *ORDERS_IMPL) CloseOrder (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -497,7 +497,7 @@ func (me *ORDERS_IMPL) CreateOrder (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -584,7 +584,7 @@ func (me *ORDERS_IMPL) CreateOrderItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -670,7 +670,7 @@ func (me *ORDERS_IMPL) GetOrderItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -755,7 +755,7 @@ func (me *ORDERS_IMPL) UpdateOrderMetadata (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -838,7 +838,7 @@ func (me *ORDERS_IMPL) GetOrder (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 

--- a/src/pagarmecoreapi_lib/orders_pkg/Orders.go
+++ b/src/pagarmecoreapi_lib/orders_pkg/Orders.go
@@ -16,9 +16,9 @@ import "pagarmecoreapi_lib/models_pkg"
 type ORDERS interface {
     GetOrders (*int64, *int64, *string, *string, *time.Time, *time.Time, *string) (*models_pkg.ListOrderResponse, error)
 
-    UpdateOrderItem (string, string, *models_pkg.UpdateOrderItemRequest, *string) (*models_pkg.GetOrderItemResponse, error)
-
     DeleteAllOrderItems (string, *string) (*models_pkg.GetOrderResponse, error)
+
+    UpdateOrderItem (string, string, *models_pkg.UpdateOrderItemRequest, *string) (*models_pkg.GetOrderItemResponse, error)
 
     DeleteOrderItem (string, string, *string) (*models_pkg.GetOrderItemResponse, error)
 

--- a/src/pagarmecoreapi_lib/pagarmecoreapi_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/pagarmecoreapi_pkg/Client.go
@@ -10,14 +10,13 @@ import(
 	"pagarmecoreapi_lib/configuration_pkg"
 	"pagarmecoreapi_lib/plans_pkg"
 	"pagarmecoreapi_lib/subscriptions_pkg"
-	"pagarmecoreapi_lib/invoices_pkg"
 	"pagarmecoreapi_lib/orders_pkg"
+	"pagarmecoreapi_lib/invoices_pkg"
 	"pagarmecoreapi_lib/customers_pkg"
-	"pagarmecoreapi_lib/recipients_pkg"
 	"pagarmecoreapi_lib/charges_pkg"
 	"pagarmecoreapi_lib/transfers_pkg"
+	"pagarmecoreapi_lib/recipients_pkg"
 	"pagarmecoreapi_lib/tokens_pkg"
-	"pagarmecoreapi_lib/sellers_pkg"
 	"pagarmecoreapi_lib/transactions_pkg"
 )
 /*
@@ -26,14 +25,13 @@ import(
 type PAGARMECOREAPI_IMPL struct {
      plans plans_pkg.PLANS
      subscriptions subscriptions_pkg.SUBSCRIPTIONS
-     invoices invoices_pkg.INVOICES
      orders orders_pkg.ORDERS
+     invoices invoices_pkg.INVOICES
      customers customers_pkg.CUSTOMERS
-     recipients recipients_pkg.RECIPIENTS
      charges charges_pkg.CHARGES
      transfers transfers_pkg.TRANSFERS
+     recipients recipients_pkg.RECIPIENTS
      tokens tokens_pkg.TOKENS
-     sellers sellers_pkg.SELLERS
      transactions transactions_pkg.TRANSACTIONS
      config  configuration_pkg.CONFIGURATION
 }
@@ -66,16 +64,6 @@ func (me *PAGARMECOREAPI_IMPL) Subscriptions() subscriptions_pkg.SUBSCRIPTIONS {
     return me.subscriptions
 }
 /**
-     * Access to Invoices controller
-     * @return Returns the Invoices() instance
-*/
-func (me *PAGARMECOREAPI_IMPL) Invoices() invoices_pkg.INVOICES {
-    if(me.invoices) == nil {
-        me.invoices = invoices_pkg.NewINVOICES(me.config)
-    }
-    return me.invoices
-}
-/**
      * Access to Orders controller
      * @return Returns the Orders() instance
 */
@@ -86,6 +74,16 @@ func (me *PAGARMECOREAPI_IMPL) Orders() orders_pkg.ORDERS {
     return me.orders
 }
 /**
+     * Access to Invoices controller
+     * @return Returns the Invoices() instance
+*/
+func (me *PAGARMECOREAPI_IMPL) Invoices() invoices_pkg.INVOICES {
+    if(me.invoices) == nil {
+        me.invoices = invoices_pkg.NewINVOICES(me.config)
+    }
+    return me.invoices
+}
+/**
      * Access to Customers controller
      * @return Returns the Customers() instance
 */
@@ -94,16 +92,6 @@ func (me *PAGARMECOREAPI_IMPL) Customers() customers_pkg.CUSTOMERS {
         me.customers = customers_pkg.NewCUSTOMERS(me.config)
     }
     return me.customers
-}
-/**
-     * Access to Recipients controller
-     * @return Returns the Recipients() instance
-*/
-func (me *PAGARMECOREAPI_IMPL) Recipients() recipients_pkg.RECIPIENTS {
-    if(me.recipients) == nil {
-        me.recipients = recipients_pkg.NewRECIPIENTS(me.config)
-    }
-    return me.recipients
 }
 /**
      * Access to Charges controller
@@ -126,6 +114,16 @@ func (me *PAGARMECOREAPI_IMPL) Transfers() transfers_pkg.TRANSFERS {
     return me.transfers
 }
 /**
+     * Access to Recipients controller
+     * @return Returns the Recipients() instance
+*/
+func (me *PAGARMECOREAPI_IMPL) Recipients() recipients_pkg.RECIPIENTS {
+    if(me.recipients) == nil {
+        me.recipients = recipients_pkg.NewRECIPIENTS(me.config)
+    }
+    return me.recipients
+}
+/**
      * Access to Tokens controller
      * @return Returns the Tokens() instance
 */
@@ -134,16 +132,6 @@ func (me *PAGARMECOREAPI_IMPL) Tokens() tokens_pkg.TOKENS {
         me.tokens = tokens_pkg.NewTOKENS(me.config)
     }
     return me.tokens
-}
-/**
-     * Access to Sellers controller
-     * @return Returns the Sellers() instance
-*/
-func (me *PAGARMECOREAPI_IMPL) Sellers() sellers_pkg.SELLERS {
-    if(me.sellers) == nil {
-        me.sellers = sellers_pkg.NewSELLERS(me.config)
-    }
-    return me.sellers
 }
 /**
      * Access to Transactions controller

--- a/src/pagarmecoreapi_lib/pagarmecoreapi_pkg/PagarmeCoreApi.go
+++ b/src/pagarmecoreapi_lib/pagarmecoreapi_pkg/PagarmeCoreApi.go
@@ -10,14 +10,13 @@ import(
 	"pagarmecoreapi_lib/configuration_pkg"
 	"pagarmecoreapi_lib/plans_pkg"
 	"pagarmecoreapi_lib/subscriptions_pkg"
-	"pagarmecoreapi_lib/invoices_pkg"
 	"pagarmecoreapi_lib/orders_pkg"
+	"pagarmecoreapi_lib/invoices_pkg"
 	"pagarmecoreapi_lib/customers_pkg"
-	"pagarmecoreapi_lib/recipients_pkg"
 	"pagarmecoreapi_lib/charges_pkg"
 	"pagarmecoreapi_lib/transfers_pkg"
+	"pagarmecoreapi_lib/recipients_pkg"
 	"pagarmecoreapi_lib/tokens_pkg"
-	"pagarmecoreapi_lib/sellers_pkg"
 	"pagarmecoreapi_lib/transactions_pkg"
 )
 
@@ -28,14 +27,13 @@ import(
 type PAGARMECOREAPI interface {
     Plans()                 plans_pkg.PLANS
     Subscriptions()         subscriptions_pkg.SUBSCRIPTIONS
-    Invoices()              invoices_pkg.INVOICES
     Orders()                orders_pkg.ORDERS
+    Invoices()              invoices_pkg.INVOICES
     Customers()             customers_pkg.CUSTOMERS
-    Recipients()            recipients_pkg.RECIPIENTS
     Charges()               charges_pkg.CHARGES
     Transfers()             transfers_pkg.TRANSFERS
+    Recipients()            recipients_pkg.RECIPIENTS
     Tokens()                tokens_pkg.TOKENS
-    Sellers()               sellers_pkg.SELLERS
     Transactions()          transactions_pkg.TRANSACTIONS
     Configuration()         configuration_pkg.CONFIGURATION
 }

--- a/src/pagarmecoreapi_lib/plans_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/plans_pkg/Client.go
@@ -57,96 +57,12 @@ func (me *PLANS_IMPL) GetPlan (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
     //prepare API request
     _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetPlanResponse = &models_pkg.GetPlanResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * Deletes a plan
- * @param    string         planId              parameter: Required
- * @param    *string        idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetPlanResponse response from the API call
- */
-func (me *PLANS_IMPL) DeletePlan (
-            planId string,
-            idempotencyKey *string) (*models_pkg.GetPlanResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/plans/{plan_id}"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "plan_id" : planId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.DeleteWithAuth(_queryBuilder, headers, nil, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
     //and invoke the API call request to fetch the response
     _response, err := unirest.AsString(_request,false);
     if err != nil {
@@ -226,7 +142,7 @@ func (me *PLANS_IMPL) UpdatePlanMetadata (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -316,7 +232,7 @@ func (me *PLANS_IMPL) UpdatePlanItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -403,7 +319,7 @@ func (me *PLANS_IMPL) CreatePlanItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -489,7 +405,7 @@ func (me *PLANS_IMPL) GetPlanItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -563,7 +479,7 @@ func (me *PLANS_IMPL) CreatePlan (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -651,7 +567,7 @@ func (me *PLANS_IMPL) DeletePlanItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -751,7 +667,7 @@ func (me *PLANS_IMPL) GetPlans (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -836,7 +752,7 @@ func (me *PLANS_IMPL) UpdatePlan (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -844,6 +760,90 @@ func (me *PLANS_IMPL) UpdatePlan (
 
     //prepare API request
     _request := unirest.PutWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetPlanResponse = &models_pkg.GetPlanResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * Deletes a plan
+ * @param    string         planId              parameter: Required
+ * @param    *string        idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetPlanResponse response from the API call
+ */
+func (me *PLANS_IMPL) DeletePlan (
+            planId string,
+            idempotencyKey *string) (*models_pkg.GetPlanResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/plans/{plan_id}"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "plan_id" : planId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.DeleteWithAuth(_queryBuilder, headers, nil, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
     //and invoke the API call request to fetch the response
     _response, err := unirest.AsString(_request,false);
     if err != nil {

--- a/src/pagarmecoreapi_lib/plans_pkg/Plans.go
+++ b/src/pagarmecoreapi_lib/plans_pkg/Plans.go
@@ -16,8 +16,6 @@ import "pagarmecoreapi_lib/models_pkg"
 type PLANS interface {
     GetPlan (string) (*models_pkg.GetPlanResponse, error)
 
-    DeletePlan (string, *string) (*models_pkg.GetPlanResponse, error)
-
     UpdatePlanMetadata (string, *models_pkg.UpdateMetadataRequest, *string) (*models_pkg.GetPlanResponse, error)
 
     UpdatePlanItem (string, string, *models_pkg.UpdatePlanItemRequest, *string) (*models_pkg.GetPlanItemResponse, error)
@@ -33,6 +31,8 @@ type PLANS interface {
     GetPlans (*int64, *int64, *string, *string, *string, *time.Time, *time.Time) (*models_pkg.ListPlansResponse, error)
 
     UpdatePlan (string, *models_pkg.UpdatePlanRequest, *string) (*models_pkg.GetPlanResponse, error)
+
+    DeletePlan (string, *string) (*models_pkg.GetPlanResponse, error)
 }
 
 /*

--- a/src/pagarmecoreapi_lib/recipients_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/recipients_pkg/Client.go
@@ -23,6 +23,90 @@ type RECIPIENTS_IMPL struct {
 }
 
 /**
+ * Gets a transfer
+ * @param    string        recipientId      parameter: Required
+ * @param    string        transferId       parameter: Required
+ * @return	Returns the *models_pkg.GetTransferResponse response from the API call
+ */
+func (me *RECIPIENTS_IMPL) GetTransfer (
+            recipientId string,
+            transferId string) (*models_pkg.GetTransferResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/recipients/{recipient_id}/transfers/{transfer_id}"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "recipient_id" : recipientId,
+        "transfer_id" : transferId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+    }
+
+    //prepare API request
+    _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetTransferResponse = &models_pkg.GetTransferResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
  * Updates a recipient
  * @param    string                                    recipientId         parameter: Required
  * @param    *models_pkg.UpdateRecipientRequest        request             parameter: Required
@@ -61,7 +145,7 @@ func (me *RECIPIENTS_IMPL) UpdateRecipient (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -148,7 +232,7 @@ func (me *RECIPIENTS_IMPL) CreateAnticipation (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -245,7 +329,7 @@ func (me *RECIPIENTS_IMPL) GetAnticipationLimits (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -329,7 +413,7 @@ func (me *RECIPIENTS_IMPL) GetRecipients (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -413,7 +497,7 @@ func (me *RECIPIENTS_IMPL) GetWithdrawById (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -498,7 +582,7 @@ func (me *RECIPIENTS_IMPL) UpdateRecipientDefaultBankAccount (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -585,7 +669,7 @@ func (me *RECIPIENTS_IMPL) UpdateRecipientMetadata (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -691,7 +775,7 @@ func (me *RECIPIENTS_IMPL) GetTransfers (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -727,90 +811,6 @@ func (me *RECIPIENTS_IMPL) GetTransfers (
 
     //returning the response
     var retVal *models_pkg.ListTransferResponse = &models_pkg.ListTransferResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * Gets a transfer
- * @param    string        recipientId      parameter: Required
- * @param    string        transferId       parameter: Required
- * @return	Returns the *models_pkg.GetTransferResponse response from the API call
- */
-func (me *RECIPIENTS_IMPL) GetTransfer (
-            recipientId string,
-            transferId string) (*models_pkg.GetTransferResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/recipients/{recipient_id}/transfers/{transfer_id}"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "recipient_id" : recipientId,
-        "transfer_id" : transferId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-    }
-
-    //prepare API request
-    _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetTransferResponse = &models_pkg.GetTransferResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -858,7 +858,7 @@ func (me *RECIPIENTS_IMPL) CreateWithdraw (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
     }
@@ -944,7 +944,7 @@ func (me *RECIPIENTS_IMPL) UpdateAutomaticAnticipationSettings (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1030,7 +1030,7 @@ func (me *RECIPIENTS_IMPL) GetAnticipation (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1115,7 +1115,7 @@ func (me *RECIPIENTS_IMPL) UpdateRecipientTransferSettings (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1230,7 +1230,7 @@ func (me *RECIPIENTS_IMPL) GetAnticipations (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1311,7 +1311,7 @@ func (me *RECIPIENTS_IMPL) GetRecipient (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1347,87 +1347,6 @@ func (me *RECIPIENTS_IMPL) GetRecipient (
 
     //returning the response
     var retVal *models_pkg.GetRecipientResponse = &models_pkg.GetRecipientResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * Get balance information for a recipient
- * @param    string        recipientId      parameter: Required
- * @return	Returns the *models_pkg.GetBalanceResponse response from the API call
- */
-func (me *RECIPIENTS_IMPL) GetBalance (
-            recipientId string) (*models_pkg.GetBalanceResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/recipients/{recipient_id}/balance"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "recipient_id" : recipientId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-    }
-
-    //prepare API request
-    _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetBalanceResponse = &models_pkg.GetBalanceResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -1496,7 +1415,7 @@ func (me *RECIPIENTS_IMPL) GetWithdrawals (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1532,6 +1451,87 @@ func (me *RECIPIENTS_IMPL) GetWithdrawals (
 
     //returning the response
     var retVal *models_pkg.ListWithdrawals = &models_pkg.ListWithdrawals{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * Get balance information for a recipient
+ * @param    string        recipientId      parameter: Required
+ * @return	Returns the *models_pkg.GetBalanceResponse response from the API call
+ */
+func (me *RECIPIENTS_IMPL) GetBalance (
+            recipientId string) (*models_pkg.GetBalanceResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/recipients/{recipient_id}/balance"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "recipient_id" : recipientId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+    }
+
+    //prepare API request
+    _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetBalanceResponse = &models_pkg.GetBalanceResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -1581,7 +1581,7 @@ func (me *RECIPIENTS_IMPL) CreateTransfer (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1657,7 +1657,7 @@ func (me *RECIPIENTS_IMPL) CreateRecipient (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1740,7 +1740,7 @@ func (me *RECIPIENTS_IMPL) GetRecipientByCode (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1810,7 +1810,7 @@ func (me *RECIPIENTS_IMPL) GetDefaultRecipient () (*models_pkg.GetRecipientRespo
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 

--- a/src/pagarmecoreapi_lib/recipients_pkg/Recipients.go
+++ b/src/pagarmecoreapi_lib/recipients_pkg/Recipients.go
@@ -14,6 +14,8 @@ import "pagarmecoreapi_lib/models_pkg"
  * Interface for the RECIPIENTS_IMPL
  */
 type RECIPIENTS interface {
+    GetTransfer (string, string) (*models_pkg.GetTransferResponse, error)
+
     UpdateRecipient (string, *models_pkg.UpdateRecipientRequest, *string) (*models_pkg.GetRecipientResponse, error)
 
     CreateAnticipation (string, *models_pkg.CreateAnticipationRequest, *string) (*models_pkg.GetAnticipationResponse, error)
@@ -30,8 +32,6 @@ type RECIPIENTS interface {
 
     GetTransfers (string, *int64, *int64, *string, *time.Time, *time.Time) (*models_pkg.ListTransferResponse, error)
 
-    GetTransfer (string, string) (*models_pkg.GetTransferResponse, error)
-
     CreateWithdraw (string, *models_pkg.CreateWithdrawRequest) (*models_pkg.GetWithdrawResponse, error)
 
     UpdateAutomaticAnticipationSettings (string, *models_pkg.UpdateAutomaticAnticipationSettingsRequest, *string) (*models_pkg.GetRecipientResponse, error)
@@ -44,9 +44,9 @@ type RECIPIENTS interface {
 
     GetRecipient (string) (*models_pkg.GetRecipientResponse, error)
 
-    GetBalance (string) (*models_pkg.GetBalanceResponse, error)
-
     GetWithdrawals (string, *int64, *int64, *string, *time.Time, *time.Time) (*models_pkg.ListWithdrawals, error)
+
+    GetBalance (string) (*models_pkg.GetBalanceResponse, error)
 
     CreateTransfer (string, *models_pkg.CreateTransferRequest, *string) (*models_pkg.GetTransferResponse, error)
 

--- a/src/pagarmecoreapi_lib/subscriptions_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/subscriptions_pkg/Client.go
@@ -23,90 +23,6 @@ type SUBSCRIPTIONS_IMPL struct {
 }
 
 /**
- * TODO: type endpoint description here
- * @param    string         subscriptionId      parameter: Required
- * @param    *string        idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetPeriodResponse response from the API call
- */
-func (me *SUBSCRIPTIONS_IMPL) RenewSubscription (
-            subscriptionId string,
-            idempotencyKey *string) (*models_pkg.GetPeriodResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/subscriptions/{subscription_id}/cycles"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "subscription_id" : subscriptionId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.PostWithAuth(_queryBuilder, headers, nil, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetPeriodResponse = &models_pkg.GetPeriodResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
  * Updates the credit card from a subscription
  * @param    string                                           subscriptionId      parameter: Required
  * @param    *models_pkg.UpdateSubscriptionCardRequest        request             parameter: Required
@@ -145,7 +61,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionCard (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -236,7 +152,7 @@ func (me *SUBSCRIPTIONS_IMPL) DeleteUsage (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -322,7 +238,7 @@ func (me *SUBSCRIPTIONS_IMPL) CreateDiscount (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -410,7 +326,7 @@ func (me *SUBSCRIPTIONS_IMPL) CreateAnUsage (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -496,7 +412,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateCurrentCycleStatus (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -533,6 +449,93 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateCurrentCycleStatus (
 
     //returning the response
     return nil
+
+}
+
+/**
+ * Updates the payment method from a subscription
+ * @param    string                                                    subscriptionId      parameter: Required
+ * @param    *models_pkg.UpdateSubscriptionPaymentMethodRequest        request             parameter: Required
+ * @param    *string                                                   idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetSubscriptionResponse response from the API call
+ */
+func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionPaymentMethod (
+            subscriptionId string,
+            request *models_pkg.UpdateSubscriptionPaymentMethodRequest,
+            idempotencyKey *string) (*models_pkg.GetSubscriptionResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/subscriptions/{subscription_id}/payment-method"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "subscription_id" : subscriptionId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "content-type" : "application/json; charset=utf-8",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.PatchWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetSubscriptionResponse = &models_pkg.GetSubscriptionResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
 
 }
 
@@ -576,7 +579,7 @@ func (me *SUBSCRIPTIONS_IMPL) DeleteDiscount (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -690,7 +693,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionItems (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -726,93 +729,6 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionItems (
 
     //returning the response
     var retVal *models_pkg.ListSubscriptionItemsResponse = &models_pkg.ListSubscriptionItemsResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
- * Updates the payment method from a subscription
- * @param    string                                                    subscriptionId      parameter: Required
- * @param    *models_pkg.UpdateSubscriptionPaymentMethodRequest        request             parameter: Required
- * @param    *string                                                   idempotencyKey      parameter: Optional
- * @return	Returns the *models_pkg.GetSubscriptionResponse response from the API call
- */
-func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionPaymentMethod (
-            subscriptionId string,
-            request *models_pkg.UpdateSubscriptionPaymentMethodRequest,
-            idempotencyKey *string) (*models_pkg.GetSubscriptionResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/subscriptions/{subscription_id}/payment-method"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "subscription_id" : subscriptionId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-        "content-type" : "application/json; charset=utf-8",
-        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
-    }
-
-    //prepare API request
-    _request := unirest.PatchWithAuth(_queryBuilder, headers, request, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetSubscriptionResponse = &models_pkg.GetSubscriptionResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -861,7 +777,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -975,7 +891,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptions (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1060,7 +976,7 @@ func (me *SUBSCRIPTIONS_IMPL) CancelSubscription (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1147,7 +1063,7 @@ func (me *SUBSCRIPTIONS_IMPL) CreateIncrement (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1237,7 +1153,7 @@ func (me *SUBSCRIPTIONS_IMPL) CreateUsage (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1286,90 +1202,6 @@ func (me *SUBSCRIPTIONS_IMPL) CreateUsage (
 }
 
 /**
- * TODO: type endpoint description here
- * @param    string        subscriptionId      parameter: Required
- * @param    string        discountId          parameter: Required
- * @return	Returns the *models_pkg.GetDiscountResponse response from the API call
- */
-func (me *SUBSCRIPTIONS_IMPL) GetDiscountById (
-            subscriptionId string,
-            discountId string) (*models_pkg.GetDiscountResponse, error) {
-    //the endpoint path uri
-    _pathUrl := "/subscriptions/{subscription_id}/discounts/{discountId}"
-
-    //variable to hold errors
-    var err error = nil
-    //process optional template parameters
-    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
-        "subscription_id" : subscriptionId,
-        "discountId" : discountId,
-    })
-    if err != nil {
-        //error in template param handling
-        return nil, err
-    }
-
-    //the base uri for api requests
-    _queryBuilder := configuration_pkg.BASEURI;
-
-    //prepare query string for API call
-   _queryBuilder = _queryBuilder + _pathUrl
-
-    //validate and preprocess url
-    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
-    if err != nil {
-        //error in url validation or cleaning
-        return nil, err
-    }
-    //prepare headers for the outgoing request
-    headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
-        "accept" : "application/json",
-    }
-
-    //prepare API request
-    _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
-    //and invoke the API call request to fetch the response
-    _response, err := unirest.AsString(_request,false);
-    if err != nil {
-        //error in API invocation
-        return nil, err
-    }
-
-    //error handling using HTTP status codes
-    if (_response.Code == 400) {
-        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
-    } else if (_response.Code == 401) {
-        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
-    } else if (_response.Code == 404) {
-        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
-    } else if (_response.Code == 412) {
-        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 422) {
-        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
-    } else if (_response.Code == 500) {
-        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
-    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
-            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
-    }
-    if(err != nil) {
-        //error detected in status code validation
-        return nil, err
-    }
-
-    //returning the response
-    var retVal *models_pkg.GetDiscountResponse = &models_pkg.GetDiscountResponse{}
-    err = json.Unmarshal(_response.RawBody, &retVal)
-
-    if err != nil {
-        //error in parsing
-        return nil, err
-    }
-    return retVal, nil
-
-}
-
-/**
  * Creates a new subscription
  * @param    *models_pkg.CreateSubscriptionRequest        body                parameter: Required
  * @param    *string                                      idempotencyKey      parameter: Optional
@@ -1397,7 +1229,7 @@ func (me *SUBSCRIPTIONS_IMPL) CreateSubscription (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1448,21 +1280,21 @@ func (me *SUBSCRIPTIONS_IMPL) CreateSubscription (
 /**
  * TODO: type endpoint description here
  * @param    string        subscriptionId      parameter: Required
- * @param    string        incrementId         parameter: Required
- * @return	Returns the *models_pkg.GetIncrementResponse response from the API call
+ * @param    string        discountId          parameter: Required
+ * @return	Returns the *models_pkg.GetDiscountResponse response from the API call
  */
-func (me *SUBSCRIPTIONS_IMPL) GetIncrementById (
+func (me *SUBSCRIPTIONS_IMPL) GetDiscountById (
             subscriptionId string,
-            incrementId string) (*models_pkg.GetIncrementResponse, error) {
+            discountId string) (*models_pkg.GetDiscountResponse, error) {
     //the endpoint path uri
-    _pathUrl := "/subscriptions/{subscription_id}/increments/{increment_id}"
+    _pathUrl := "/subscriptions/{subscription_id}/discounts/{discountId}"
 
     //variable to hold errors
     var err error = nil
     //process optional template parameters
     _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
         "subscription_id" : subscriptionId,
-        "increment_id" : incrementId,
+        "discountId" : discountId,
     })
     if err != nil {
         //error in template param handling
@@ -1483,7 +1315,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetIncrementById (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1518,7 +1350,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetIncrementById (
     }
 
     //returning the response
-    var retVal *models_pkg.GetIncrementResponse = &models_pkg.GetIncrementResponse{}
+    var retVal *models_pkg.GetDiscountResponse = &models_pkg.GetDiscountResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -1568,7 +1400,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionAffiliationId (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1655,7 +1487,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionMetadata (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -1743,7 +1575,7 @@ func (me *SUBSCRIPTIONS_IMPL) DeleteIncrement (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -1839,7 +1671,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionCycles (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -1875,6 +1707,90 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionCycles (
 
     //returning the response
     var retVal *models_pkg.ListCyclesResponse = &models_pkg.ListCyclesResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * TODO: type endpoint description here
+ * @param    string        subscriptionId      parameter: Required
+ * @param    string        incrementId         parameter: Required
+ * @return	Returns the *models_pkg.GetIncrementResponse response from the API call
+ */
+func (me *SUBSCRIPTIONS_IMPL) GetIncrementById (
+            subscriptionId string,
+            incrementId string) (*models_pkg.GetIncrementResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/subscriptions/{subscription_id}/increments/{increment_id}"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "subscription_id" : subscriptionId,
+        "increment_id" : incrementId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+    }
+
+    //prepare API request
+    _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetIncrementResponse = &models_pkg.GetIncrementResponse{}
     err = json.Unmarshal(_response.RawBody, &retVal)
 
     if err != nil {
@@ -1934,7 +1850,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetDiscounts (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -2019,7 +1935,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionBillingDate (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -2107,7 +2023,7 @@ func (me *SUBSCRIPTIONS_IMPL) DeleteSubscriptionItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
     }
@@ -2203,7 +2119,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetIncrements (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -2288,7 +2204,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionDueDays (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -2375,7 +2291,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionStartAt (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -2465,7 +2381,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -2552,7 +2468,7 @@ func (me *SUBSCRIPTIONS_IMPL) CreateSubscriptionItem (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -2635,7 +2551,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscription (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -2745,7 +2661,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetUsages (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -2830,7 +2746,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateLatestPeriodEndAt (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -2917,7 +2833,7 @@ func (me *SUBSCRIPTIONS_IMPL) UpdateSubscriptionMiniumPrice (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -3003,12 +2919,96 @@ func (me *SUBSCRIPTIONS_IMPL) GetSubscriptionCycleById (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
     //prepare API request
     _request := unirest.GetWithAuth(_queryBuilder, headers, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
+    //and invoke the API call request to fetch the response
+    _response, err := unirest.AsString(_request,false);
+    if err != nil {
+        //error in API invocation
+        return nil, err
+    }
+
+    //error handling using HTTP status codes
+    if (_response.Code == 400) {
+        err = apihelper_pkg.NewAPIError("Invalid request", _response.Code, _response.RawBody)
+    } else if (_response.Code == 401) {
+        err = apihelper_pkg.NewAPIError("Invalid API key", _response.Code, _response.RawBody)
+    } else if (_response.Code == 404) {
+        err = apihelper_pkg.NewAPIError("An informed resource was not found", _response.Code, _response.RawBody)
+    } else if (_response.Code == 412) {
+        err = apihelper_pkg.NewAPIError("Business validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 422) {
+        err = apihelper_pkg.NewAPIError("Contract validation error", _response.Code, _response.RawBody)
+    } else if (_response.Code == 500) {
+        err = apihelper_pkg.NewAPIError("Internal server error", _response.Code, _response.RawBody)
+    } else if (_response.Code < 200) || (_response.Code > 206) { //[200,206] = HTTP OK
+            err = apihelper_pkg.NewAPIError("HTTP Response Not OK", _response.Code, _response.RawBody)
+    }
+    if(err != nil) {
+        //error detected in status code validation
+        return nil, err
+    }
+
+    //returning the response
+    var retVal *models_pkg.GetPeriodResponse = &models_pkg.GetPeriodResponse{}
+    err = json.Unmarshal(_response.RawBody, &retVal)
+
+    if err != nil {
+        //error in parsing
+        return nil, err
+    }
+    return retVal, nil
+
+}
+
+/**
+ * TODO: type endpoint description here
+ * @param    string         subscriptionId      parameter: Required
+ * @param    *string        idempotencyKey      parameter: Optional
+ * @return	Returns the *models_pkg.GetPeriodResponse response from the API call
+ */
+func (me *SUBSCRIPTIONS_IMPL) RenewSubscription (
+            subscriptionId string,
+            idempotencyKey *string) (*models_pkg.GetPeriodResponse, error) {
+    //the endpoint path uri
+    _pathUrl := "/subscriptions/{subscription_id}/cycles"
+
+    //variable to hold errors
+    var err error = nil
+    //process optional template parameters
+    _pathUrl, err = apihelper_pkg.AppendUrlWithTemplateParameters(_pathUrl, map[string]interface{} {
+        "subscription_id" : subscriptionId,
+    })
+    if err != nil {
+        //error in template param handling
+        return nil, err
+    }
+
+    //the base uri for api requests
+    _queryBuilder := configuration_pkg.BASEURI;
+
+    //prepare query string for API call
+   _queryBuilder = _queryBuilder + _pathUrl
+
+    //validate and preprocess url
+    _queryBuilder, err = apihelper_pkg.CleanUrl(_queryBuilder)
+    if err != nil {
+        //error in url validation or cleaning
+        return nil, err
+    }
+    //prepare headers for the outgoing request
+    headers := map[string]interface{} {
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
+        "accept" : "application/json",
+        "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
+    }
+
+    //prepare API request
+    _request := unirest.PostWithAuth(_queryBuilder, headers, nil, me.config.BasicAuthUserName(), me.config.BasicAuthPassword())
     //and invoke the API call request to fetch the response
     _response, err := unirest.AsString(_request,false);
     if err != nil {
@@ -3087,7 +3087,7 @@ func (me *SUBSCRIPTIONS_IMPL) GetUsageReport (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 

--- a/src/pagarmecoreapi_lib/subscriptions_pkg/Subscriptions.go
+++ b/src/pagarmecoreapi_lib/subscriptions_pkg/Subscriptions.go
@@ -14,8 +14,6 @@ import "pagarmecoreapi_lib/models_pkg"
  * Interface for the SUBSCRIPTIONS_IMPL
  */
 type SUBSCRIPTIONS interface {
-    RenewSubscription (string, *string) (*models_pkg.GetPeriodResponse, error)
-
     UpdateSubscriptionCard (string, *models_pkg.UpdateSubscriptionCardRequest, *string) (*models_pkg.GetSubscriptionResponse, error)
 
     DeleteUsage (string, string, string, *string) (*models_pkg.GetUsageResponse, error)
@@ -26,11 +24,11 @@ type SUBSCRIPTIONS interface {
 
     UpdateCurrentCycleStatus (string, *models_pkg.UpdateCurrentCycleStatusRequest, *string) (error)
 
+    UpdateSubscriptionPaymentMethod (string, *models_pkg.UpdateSubscriptionPaymentMethodRequest, *string) (*models_pkg.GetSubscriptionResponse, error)
+
     DeleteDiscount (string, string, *string) (*models_pkg.GetDiscountResponse, error)
 
     GetSubscriptionItems (string, *int64, *int64, *string, *string, *string, *string, *string, *string) (*models_pkg.ListSubscriptionItemsResponse, error)
-
-    UpdateSubscriptionPaymentMethod (string, *models_pkg.UpdateSubscriptionPaymentMethodRequest, *string) (*models_pkg.GetSubscriptionResponse, error)
 
     GetSubscriptionItem (string, string) (*models_pkg.GetSubscriptionItemResponse, error)
 
@@ -42,11 +40,9 @@ type SUBSCRIPTIONS interface {
 
     CreateUsage (string, string, *models_pkg.CreateUsageRequest, *string) (*models_pkg.GetUsageResponse, error)
 
-    GetDiscountById (string, string) (*models_pkg.GetDiscountResponse, error)
-
     CreateSubscription (*models_pkg.CreateSubscriptionRequest, *string) (*models_pkg.GetSubscriptionResponse, error)
 
-    GetIncrementById (string, string) (*models_pkg.GetIncrementResponse, error)
+    GetDiscountById (string, string) (*models_pkg.GetDiscountResponse, error)
 
     UpdateSubscriptionAffiliationId (string, *models_pkg.UpdateSubscriptionAffiliationIdRequest, *string) (*models_pkg.GetSubscriptionResponse, error)
 
@@ -55,6 +51,8 @@ type SUBSCRIPTIONS interface {
     DeleteIncrement (string, string, *string) (*models_pkg.GetIncrementResponse, error)
 
     GetSubscriptionCycles (string, string, string) (*models_pkg.ListCyclesResponse, error)
+
+    GetIncrementById (string, string) (*models_pkg.GetIncrementResponse, error)
 
     GetDiscounts (string, int64, int64) (*models_pkg.ListDiscountsResponse, error)
 
@@ -81,6 +79,8 @@ type SUBSCRIPTIONS interface {
     UpdateSubscriptionMiniumPrice (string, *models_pkg.UpdateSubscriptionMinimumPriceRequest, *string) (*models_pkg.GetSubscriptionResponse, error)
 
     GetSubscriptionCycleById (string, string) (*models_pkg.GetPeriodResponse, error)
+
+    RenewSubscription (string, *string) (*models_pkg.GetPeriodResponse, error)
 
     GetUsageReport (string, string) (*models_pkg.GetUsageReportResponse, error)
 }

--- a/src/pagarmecoreapi_lib/tokens_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/tokens_pkg/Client.go
@@ -60,7 +60,7 @@ func (me *TOKENS_IMPL) CreateToken (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
         "idempotency-key" : apihelper_pkg.ToString(idempotencyKey, ""),
@@ -146,7 +146,7 @@ func (me *TOKENS_IMPL) GetToken (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 

--- a/src/pagarmecoreapi_lib/transactions_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/transactions_pkg/Client.go
@@ -56,7 +56,7 @@ func (me *TRANSACTIONS_IMPL) GetTransaction (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 

--- a/src/pagarmecoreapi_lib/transfers_pkg/Client.go
+++ b/src/pagarmecoreapi_lib/transfers_pkg/Client.go
@@ -56,7 +56,7 @@ func (me *TRANSFERS_IMPL) GetTransferById (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 
@@ -128,7 +128,7 @@ func (me *TRANSFERS_IMPL) CreateTransfer (
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
         "content-type" : "application/json; charset=utf-8",
     }
@@ -199,7 +199,7 @@ func (me *TRANSFERS_IMPL) GetTransfers () (*models_pkg.ListTransfers, error) {
     }
     //prepare headers for the outgoing request
     headers := map[string]interface{} {
-        "user-agent" : "PagarmeCoreApi - Go 5.2.0",
+        "user-agent" : "PagarmeCoreApi - Go 5.3.0",
         "accept" : "application/json",
     }
 


### PR DESCRIPTION
The customer should no longer use the Mark1 Sellers endpoint as it is outdated. We need to remove it from the SDK so it no longer has access.